### PR TITLE
Add Build Target and Fix Bugs

### DIFF
--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -54,10 +54,22 @@ defn get-build-args () -> Tuple<String>:
     (x:String): [x]
     (x:False): []
 
+defn get-build-target (cmd-args:CommandArgs) -> Tuple<String> :
+  val arg = args(cmd-args)
+  switch(length(arg)):
+    1:
+      debug("Target: '%_'" % [arg[0]])
+      [arg[0]]
+    0: []
+    else:
+      error("Invalid Number of Targets: %_" % [length(arg)])
+
 public defn build (cmd-args:CommandArgs) -> False:
   val verbose =  get?(cmd-args, "verbose", false)
   if verbose:
     slm/flags/debug? = true
+
+  val targ? = get-build-target(cmd-args)
 
   ensure-slm-dir-structure-exists()
 
@@ -71,7 +83,7 @@ public defn build (cmd-args:CommandArgs) -> False:
   val build-args = get-build-args()
   debug("with build args '%,'" % [build-args])
 
-  val args = to-tuple $ cat-all([["stanza", "build"], build-args, ["-pkg", "pkgs"]])
+  val args = to-tuple $ cat-all([["stanza", "build"], targ?, build-args, ["-pkg", "pkgs"]])
   ProcessBuilder(args)
     $> in-dir{_, slm-dir}
     $> build
@@ -92,6 +104,28 @@ $> SLM_BUILD_ARGS="-flag TESTING" slm build
 
 <MSG>
 
+val BUILD-MSG-ARG = \<MSG>
+
+The build command takes an optional argument which is the target in the
+stanza.proj file to build. Without this optional argument, the command
+follows the `stanza build` command's logic and compiles the `main` target.
+
+Running:
+
+```
+$> slm build target
+```
+
+Is effectively the same as running:
+
+```
+$> stanza build target
+```
+
+But with all the dependencies handled.
+
+<MSG>
+
 val VERBOSE-FLAG = \<MSG>
 Generate verbose output from build.
 <MSG>
@@ -100,4 +134,4 @@ public defn setup-build-cmd () -> Command :
   val buildFlags = [
     Flag("verbose", ZeroFlag, OptionalFlag, VERBOSE-FLAG)
   ]
-  Command("build", ZeroArg, false, buildFlags, BUILD-MSG, build)
+  Command("build", ZeroOrOneArg, BUILD-MSG-ARG, buildFlags, BUILD-MSG, build)

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -19,7 +19,6 @@ defpackage slm/commands/build:
   import slm/process-utils
   import slm/flags
 
-
 public defn ensure-slm-dir-structure-exists () -> False:
   defn create-dir! (path: String) -> True|False:
     if not file-exists?(path):
@@ -43,10 +42,10 @@ defn write-slm-lock-file (dependencies: Tuple<Dependency>) -> False:
   within f = open("slm.lock", false):
     for dep in dependencies do:
       match(dep):
-        (dep: GitDependency): 
+        (dep: GitDependency):
           println(f, "%_={locator=%~,version=%~,hash=%~}"
                   % [name(dep), locator(dep), to-string(version(dep)), hash(dep)])
-        (dep: PathDependency): 
+        (dep: PathDependency):
           println(f, "%_={}" % [name(dep)])
 
 defn get-build-args () -> Tuple<String>:
@@ -77,7 +76,7 @@ public defn build (cmd-args:CommandArgs) -> False:
     $> in-dir{_, slm-dir}
     $> build
     $> wait-process-throw-on-nonzero{_, "build failed!"}
-    
+
   false
 
 val BUILD-MSG = \<MSG>

--- a/src/commands/init.stanza
+++ b/src/commands/init.stanza
@@ -135,14 +135,14 @@ Content Created:
   - stanza.proj
   - src directory and initial main.stanza
 
-Example: 
+Example:
 
 Initialize a brand new project:
 
 $> cd new_project
 $> slm init
 
-Initialize an existing project: 
+Initialize an existing project:
 
 $> git clone ssh://git@github.com/user/existing
 $> slm init ./existing

--- a/src/dependencies.stanza
+++ b/src/dependencies.stanza
@@ -224,6 +224,6 @@ defn resolve-path-dependency? (
     ; This scenario shouldn't occur, because we parse all top-level dependencies
     ; first, and we only allow path dependencies at the top-level, hence path dependencies get
     ; resolved first.
-    ; could occur is if 
+    ; could occur is if
     fatal("internal inconsistency resolving path dependency '%_'" % [name(dep)])
   One(dep)

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -4,7 +4,7 @@ defpackage slm/dependency:
   import semver
   import term-colors
   import maybe-utils
-  
+
   import slm/logging
   import slm/utils
 

--- a/src/logging.stanza
+++ b/src/logging.stanza
@@ -39,13 +39,7 @@ public defn info (msg: Printable|String) -> False:
   println(STANDARD-OUTPUT-STREAM, "%_ %_" % [program-prefix(), msg])
   flush(STANDARD-OUTPUT-STREAM as FileOutputStream)
 
-public defn error-with-usage (msg: Printable|String) -> Void:
-  error(msg, true)
-
 public defn error (msg: Printable|String) -> Void:
-  error(msg, false)
-
-defn error (msg: Printable|String, usage?: True|False) -> Void:
   val program = program-name()
   println(STANDARD-ERROR-STREAM, "%_ %_ %_" % [
     program-prefix(),
@@ -54,7 +48,5 @@ defn error (msg: Printable|String, usage?: True|False) -> Void:
       $> clear-color?,
     msg,
   ])
-  if usage?:
-    println(STANDARD-ERROR-STREAM, "usage: %_ [build|clean|init|publish|repl]" % [program])
   exit(1)
 

--- a/src/logging.stanza
+++ b/src/logging.stanza
@@ -23,7 +23,7 @@ defn program-prefix () -> ColoredString|String:
 
 public defn debug (msg: Printable|String) -> False:
   if slm/flags/debug?:
-    println(STANDARD-ERROR-STREAM, "%_ %_%_%_" % [
+    println(current-error-stream(), "%_ %_%_%_" % [
       program-prefix(),
       ColoredString("debug: ")
         $> bold $> dim $> foreground{_, TerminalYellow}
@@ -36,12 +36,12 @@ public defn debug (msg: Printable|String) -> False:
     ])
 
 public defn info (msg: Printable|String) -> False:
-  println(STANDARD-OUTPUT-STREAM, "%_ %_" % [program-prefix(), msg])
-  flush(STANDARD-OUTPUT-STREAM as FileOutputStream)
+  println(current-output-stream(), "%_ %_" % [program-prefix(), msg])
+  flush(current-output-stream() as FileOutputStream)
 
 public defn error (msg: Printable|String) -> Void:
   val program = program-name()
-  println(STANDARD-ERROR-STREAM, "%_ %_ %_" % [
+  println(current-error-stream(), "%_ %_ %_" % [
     program-prefix(),
     ColoredString("error:")
       $> bold $> foreground{_, TerminalBrightRed}

--- a/src/toml.stanza
+++ b/src/toml.stanza
@@ -21,7 +21,7 @@ public defn parse-slm-toml (path: String) -> SlmToml:
   val table = path $> parse-file $> table
   val name = table["name"] as String
   val version = table["version"] as String
-  val dependencies = to-hashtable<String, Dependency> $ 
+  val dependencies = to-hashtable<String, Dependency> $
     for [name, specifier] in pairs(table["dependencies"] as TomlTable) seq:
       name => match(specifier):
         (specifier: String):


### PR DESCRIPTION
Closes #36

User can now run: 

```
$> slm build tests
```

And slm will build the `tests` target in the project's `stanza.proj` file (assuming it exists).