### PR TITLE
Add Version from EnvVar

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,39 @@ Just download a release from [releases](https://github.com/StanzaOrg/slm/release
 
 # Usage
 
+The `slm` command has several sub-commands that are used to accomplish the build process.
+
+## Initialize
+
 To initialize a `slm` package, use `slm init`. This will initialize a Git repository into the given directory, and create a basic package structure comprising the `.slm` directory and `slm.toml`. If a directory is not specified, the current directory is used. This command can be used to create an entirely new package, or to create a package from an existing project, and *will not* overwrite any of your existing files.
+
+### `slm.toml` Structure
+
+Here is a typical `slm.toml` file structure:
+
+```toml
+name = "slm"
+version = "0.3.2"
+
+[dependencies]
+stanza-toml = "StanzaOrg/stanza-toml|0.3.4"
+semver      = "StanzaOrg/semver|0.1.4"
+maybe-utils = "StanzaOrg/maybe-utils|0.1.4"
+term-colors = "StanzaOrg/term-colors|0.1.1"
+```
+
+## Build
 
 To build a `slm` package, use `slm build`. This will create the `.slm` directory if necessary, fetch any dependencies as specified in your `slm.toml`, and then invoke `stanza build`, forwarding it any arguments given. It will also create a `slm.lock` file alongside your `slm.toml` that encapsulates the state of your dependencies at build time, so that subsequent builds do not have to fetch dependencies anew.
 
+`slm` will define the `SLM_BUILD_VERSION` environment variable in the context of the `stanza build` process. This environment variable will be populated with the value of the `version` key from the `slm.toml` file for the project being built. This allows the project being built to incorporate this version number in any library or executable that it generates. See
+the `slm/commands/version` package for an example of how to use this in your project.
+
+## Publish
+
 To publish a `slm` package, use `slm publish`. For now, you must also have set an upstream (for example, by using `git branch -u <upstream-repo-url>`) for the branch you are on. You must also be in a clean state (no outstanding changes). `slm` will `git tag` the current version (as specified in your `slm.toml`) and then push it to your upstream.
+
+## Clean
 
 To clean a `slm` package, use `slm clean`. This removes any fetched dependencies and clears your build cache.
 

--- a/ci/download-stanza.sh
+++ b/ci/download-stanza.sh
@@ -6,8 +6,7 @@ STANZA_DIR="$(pwd)/.deps/stanza"
 mkdir -p "${STANZA_DIR}"
 
 # Download archive from lbstanza.org and unpack
-STANZA_VERSION=0_17_52
-wget "https://github.com/StanzaOrg/lbstanza/releases/download/0.18.38/lstanza_0_18_38.zip" \
+wget "https://github.com/StanzaOrg/lbstanza/releases/download/0.18.52/lstanza_0_18_52.zip" \
     -O stanza.zip
 unzip stanza.zip -d "${STANZA_DIR}"
 rm -rf stanza.zip

--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "slm"
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies]
 stanza-toml = "StanzaOrg/stanza-toml|0.3.4"

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -18,6 +18,7 @@ defpackage slm/commands/build:
   import slm/logging
   import slm/process-utils
   import slm/flags
+  import slm/toml
 
 public defn ensure-slm-dir-structure-exists () -> False:
   defn create-dir! (path: String) -> True|False:
@@ -84,8 +85,13 @@ public defn build (cmd-args:CommandArgs) -> False:
   debug("with build args '%,'" % [build-args])
 
   val args = to-tuple $ cat-all([["stanza", "build"], targ?, build-args, ["-pkg", "pkgs"]])
+  val vStr = parse-slm-toml("slm.toml") $> /version
+  debug("Build Version: %_" % [vStr])
+  val env-vars = ["SLM_BUILD_VERSION" => vStr]
+  debug("Stanza: %," % [args])
   ProcessBuilder(args)
     $> in-dir{_, slm-dir}
+    $> with-env-vars{_, env-vars}
     $> build
     $> wait-process-throw-on-nonzero{_, "build failed!"}
 

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -51,7 +51,7 @@ defn write-slm-lock-file (dependencies: Tuple<Dependency>) -> False:
 defn get-build-args () -> Tuple<String>:
   val ret = get-env("SLM_BUILD_ARGS")
   match(ret):
-    (x:String): [x]
+    (x:String): to-tuple $ split(x, " ")
     (x:False): []
 
 defn get-build-target (cmd-args:CommandArgs) -> Tuple<String> :

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -108,6 +108,19 @@ Example:
 
 $> SLM_BUILD_ARGS="-flag TESTING" slm build
 
+---------------------------
+Package Version Propagation
+---------------------------
+
+In order for the package's source code to know what its current
+version number is, this tool defines 'SLM_BUILD_VERSION' with the
+'version' string value from the 'slm.toml' file. This environment
+variable is defined for the context of the `stanza build` process.
+
+This allows the package's stanza code to use '#env-var(SLM_BUILD_VERSION)'
+to access this version string and compile it into the binary or library
+that is being constructed.
+
 <MSG>
 
 val BUILD-MSG-ARG = \<MSG>

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -44,6 +44,19 @@ Example:
 
 $> SLM_REPL_ARGS="-flag TESTING" slm repl
 
+---------------------------
+Package Version Propagation
+---------------------------
+
+In order for the package's source code to know what its current
+version number is, this tool defines 'SLM_BUILD_VERSION' with the
+'version' string value from the 'slm.toml' file. This environment
+variable is defined for the context of the `stanza repl` process.
+
+This allows the package's stanza code to use '#env-var(SLM_BUILD_VERSION)'
+or 'get-env("SLM_BUILD_VERSION")' to access this version string and
+compile it into the functions accessed by the repl.
+
 <MSG>
 
 public defn setup-repl-cmd () -> Command :

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -4,6 +4,9 @@ defpackage slm/commands/repl:
 
   import slm/file-utils
   import slm/process-utils
+  import slm/logging
+  import slm/toml
+
 
 defn get-repl-args () -> Tuple<String>:
   val ret = get-env("SLM_REPL_ARGS")
@@ -16,8 +19,14 @@ public defn repl (cmd-args:CommandArgs) -> False:
   val args = to-tuple $ cat-all([["stanza", "repl"], repl-args, ["-pkg", "pkgs"]])
   val slm-dir = to-string("%_/.slm" % [get-cwd()])
 
+  val vStr = parse-slm-toml("slm.toml") $> /version
+  debug("Build Version: %_" % [vStr])
+  val env-vars = ["SLM_BUILD_VERSION" => vStr]
+  debug("Stanza: %," % [args])
+
   ProcessBuilder(args)
     $> in-dir{_, slm-dir}
+    $> with-env-vars{_, env-vars}
     $> build
     $> run-and-get-exit-code
     $> exit

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -8,7 +8,7 @@ defpackage slm/commands/repl:
 defn get-repl-args () -> Tuple<String>:
   val ret = get-env("SLM_REPL_ARGS")
   match(ret):
-    (x:String): [x]
+    (x:String): to-tuple $ split(x, " ")
     (x:False): []
 
 public defn repl (cmd-args:CommandArgs) -> False:

--- a/src/commands/version.stanza
+++ b/src/commands/version.stanza
@@ -2,8 +2,22 @@ defpackage slm/commands/version:
   import core
   import arg-parser
 
+; This definition is extracted from the environment variables
+;   at build time only.
+val v:String|False = #env-var(SLM_BUILD_VERSION)
+
+defn get-version-from-build-env () -> String:
+  match(v):
+    (x:False): ""
+    (x:String): trim(x)
+
+val BIN-VERSION = get-version-from-build-env()
+
 public defn version (cmd-args:CommandArgs) -> False:
-  println("0.3.1")
+  if length(BIN-VERSION) == 0:
+    println("dev")
+  else:
+    println("%_" % [BIN-VERSION])
 
 val VERSION-MSG = \<MSG>
 Print the version information for this utility.

--- a/src/process-utils.stanza
+++ b/src/process-utils.stanza
@@ -1,27 +1,39 @@
 defpackage slm/process-utils:
   import core
 
+  import maybe-utils
   import slm/file-utils
 
 public defstruct ProcessBuilder:
   args: Tuple<String>
-  working-dir?: Maybe<String> with: (default => None())
-  output?: True|False with: (default => false)
+  working-dir?: Maybe<String> with: (
+    default => None(),
+    updater => sub-working-dir?
+    )
+  output?: True|False with: (
+    default => false,
+    updater => sub-output?
+    )
+  env-vars: Tuple<KeyValue<String, String>> with: (
+    default => [],
+    updater => sub-env-vars
+    )
 
 public defn with-output (builder: ProcessBuilder) -> ProcessBuilder:
-  ProcessBuilder(args(builder), working-dir?(builder), true)
+  sub-output?(builder, true)
 
 public defn in-dir (builder: ProcessBuilder, dir: String) -> ProcessBuilder:
-  ProcessBuilder(args(builder), One(dir), output?(builder))
+  sub-working-dir?(builder, One(dir))
+
+public defn with-env-vars (builder:ProcessBuilder, env-vars:Tuple<KeyValue<String, String>>) -> ProcessBuilder :
+  sub-env-vars(builder, env-vars)
 
 public defn build (builder: ProcessBuilder) -> Process:
   val args = args(builder)
   val output-stream = if output?(builder): (PROCESS-OUT) else: (STANDARD-OUT)
-  val working-dir? = working-dir?(builder)
-  match(working-dir?: One<String>):
-    Process(args[0], args, STANDARD-IN, output-stream, STANDARD-ERR, value!(working-dir?), false)
-  else:
-    Process(args[0], args, STANDARD-IN, output-stream, STANDARD-ERR)
+  val workdir = value-or(working-dir?(builder), false)
+  val env-vars = env-vars(builder)
+  Process(args[0], args, STANDARD-IN, output-stream, STANDARD-ERR, workdir, env-vars)
 
 public defn get-output (p: Process) -> String:
   slurp-stream(output-stream(p))


### PR DESCRIPTION
This PR fixes some bugs and adds the ability to pull the version key from the `slm.toml` file and pass it to the library/binary being built as an environment variable. 

This requires stanza version 0.18.51 or greater. 

**Note** - If you want to try incrementing the version to see it update properly - you will likely need to run `stanza clean` to wipe the `pkg-cache`. Otherwise, the old version will be used and you will get an undesired result. 