### PR TITLE
Added the ability to change the `stanza` executable.

### DIFF
--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -82,14 +82,15 @@ public defn build (cmd-args:CommandArgs) -> False:
 
   val slm-dir = to-string("%_/.slm" % [get-cwd()])
 
-  val stanza-exe = get-stanza-exe()
+  val cfg = parse-slm-toml("slm.toml")
+  val stanza-exe = get-stanza-exe(compiler?(cfg))
   debug("with stanza='%_'" % [stanza-exe])
 
   val build-args = get-build-args()
   debug("with build args '%,'" % [build-args])
 
   val args = to-tuple $ cat-all([[stanza-exe, "build"], targ?, build-args, ["-pkg", "pkgs"]])
-  val vStr = parse-slm-toml("slm.toml") $> /version
+  val vStr =  version(cfg)
   debug("Build Version: %_" % [vStr])
   val env-vars = ["SLM_BUILD_VERSION" => vStr]
   debug("Stanza: %," % [args])

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -19,6 +19,7 @@ defpackage slm/commands/build:
   import slm/process-utils
   import slm/flags
   import slm/toml
+  import slm/utils
 
 public defn ensure-slm-dir-structure-exists () -> False:
   defn create-dir! (path: String) -> True|False:
@@ -81,10 +82,13 @@ public defn build (cmd-args:CommandArgs) -> False:
 
   val slm-dir = to-string("%_/.slm" % [get-cwd()])
 
+  val stanza-exe = get-stanza-exe()
+  debug("with stanza='%_'" % [stanza-exe])
+
   val build-args = get-build-args()
   debug("with build args '%,'" % [build-args])
 
-  val args = to-tuple $ cat-all([["stanza", "build"], targ?, build-args, ["-pkg", "pkgs"]])
+  val args = to-tuple $ cat-all([[stanza-exe, "build"], targ?, build-args, ["-pkg", "pkgs"]])
   val vStr = parse-slm-toml("slm.toml") $> /version
   debug("Build Version: %_" % [vStr])
   val env-vars = ["SLM_BUILD_VERSION" => vStr]

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -6,7 +6,7 @@ defpackage slm/commands/repl:
   import slm/process-utils
   import slm/logging
   import slm/toml
-
+  import slm/utils
 
 defn get-repl-args () -> Tuple<String>:
   val ret = get-env("SLM_REPL_ARGS")
@@ -15,8 +15,9 @@ defn get-repl-args () -> Tuple<String>:
     (x:False): []
 
 public defn repl (cmd-args:CommandArgs) -> False:
+  val stanza-exe = get-stanza-exe()
   val repl-args = get-repl-args()
-  val args = to-tuple $ cat-all([["stanza", "repl"], repl-args, ["-pkg", "pkgs"]])
+  val args = to-tuple $ cat-all([[stanza-exe, "repl"], repl-args, ["-pkg", "pkgs"]])
   val slm-dir = to-string("%_/.slm" % [get-cwd()])
 
   val vStr = parse-slm-toml("slm.toml") $> /version

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -15,12 +15,13 @@ defn get-repl-args () -> Tuple<String>:
     (x:False): []
 
 public defn repl (cmd-args:CommandArgs) -> False:
-  val stanza-exe = get-stanza-exe()
+  val cfg = parse-slm-toml("slm.toml")
+  val stanza-exe = get-stanza-exe(compiler?(cfg))
   val repl-args = get-repl-args()
   val args = to-tuple $ cat-all([[stanza-exe, "repl"], repl-args, ["-pkg", "pkgs"]])
   val slm-dir = to-string("%_/.slm" % [get-cwd()])
 
-  val vStr = parse-slm-toml("slm.toml") $> /version
+  val vStr =  version(cfg)
   debug("Build Version: %_" % [vStr])
   val env-vars = ["SLM_BUILD_VERSION" => vStr]
   debug("Stanza: %," % [args])

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -40,6 +40,9 @@ Environment Variables:
     'https' -> HTTPS Protocol
     'git' -> Git Protocol
     The default is 'git'.
+- 'SLM_STANZA' = This variable can select the name and/or path to
+    the stanza executable. This allows for usage with macro extended
+    compilers.
 
 <MSG>
 

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -24,7 +24,7 @@ slm - Stanza Library Manager
 Invocation:
 slm [build|clean|init|repl|publish|version|help]
 
-This tool provides a means of creating, buliding, and publishing
+This tool provides a means of creating, building, and publishing
 stanza libraries and tools. Think of it as something similar to
 rust's 'cargo'.
 
@@ -42,7 +42,72 @@ Environment Variables:
     The default is 'git'.
 - 'SLM_STANZA' = This variable can select the name and/or path to
     the stanza executable. This allows for usage with macro extended
-    compilers.
+    compilers. If set, this value will override the 'compiler'
+    setting in the `slm.toml` file.
+
+Configuration File:
+
+The 'slm.toml' file is the main configuration file for a project
+managed by 'slm'. This file should be found in the root directory
+of the project. It is a formatted with "Tom's Obvious Minimal Language"
+which is a minimal configuration format. See https://toml.io/ for more
+info.
+
+Configuration Keys:
+
+- name         :  Name of the project. This should match the
+                  top-level namespace of the packages defined in
+                  this project. This string should be a valid stanza
+                  identifier.
+- version      :  Current Version of the Project. This string should
+                  be a semantic version format. It will be passed to
+                  the project at build time via environment variable.
+                  See the 'build' command for more info.
+- compiler     :  Optional compiler executable name/filepath to override
+                  the default of 'stanza'.
+- dependencies :  Table with key-value pairs that indicate the dependencies
+                  for this project. See more info below.
+
+Example Configuration File:
+
+"""
+name = "slm"
+version = "0.3.2"
+
+[dependencies]
+stanza-toml = "StanzaOrg/stanza-toml|0.3.4"
+semver      = "StanzaOrg/semver|0.1.4"
+maybe-utils = "StanzaOrg/maybe-utils|0.1.4"
+term-colors = "StanzaOrg/term-colors|0.1.1"
+"""
+
+Dependency Declarations:
+
+The dependency declarations include a project name followed by a
+resolution object for that project. The resolution paths come in two
+forms:
+
+1.  Github Resolution
+
+The github resolution is a String formatted as:
+
+dep-projet = "ORG/PROJECT|SEMVER"
+
+ - dep-project = Name of the dependency we are resolving.
+ - ORG = The Github Organization where the project can be found.
+ - PROJECT = Name of the project under the github org.
+ - SEMVER = Semantic version for the project. This semantic version
+    must match a tag on the 'https://github.com/ORG/PROJECT' repository.
+
+2.  File Path Resolution
+
+The File Path resolution is an "Inline Table" object in the form:
+
+dep-project = { path = "/Full/Path/Here" }
+
+The 'path' attribute of this object makes reference to a file path
+on the local computer that is accessible through the filesystem.
+
 
 <MSG>
 

--- a/src/toml.stanza
+++ b/src/toml.stanza
@@ -15,12 +15,16 @@ defpackage slm/toml:
 public defstruct SlmToml:
   name: String
   version: String
+  compiler?: Maybe<String>
   dependencies: HashTable<String, Dependency>
 
 public defn parse-slm-toml (path: String) -> SlmToml:
   val table = path $> parse-file $> table
   val name = table["name"] as String
   val version = table["version"] as String
+  val compiler? = match(get?(table, "compiler")):
+    (x:None): x
+    (x:One<TomlValue>):  One(value(x) as String)
   val dependencies = to-hashtable<String, Dependency> $
     for [name, specifier] in pairs(table["dependencies"] as TomlTable) seq:
       name => match(specifier):
@@ -32,4 +36,4 @@ public defn parse-slm-toml (path: String) -> SlmToml:
           error("invalid slm.toml: '%_' is not a valid dependency specifier"
                 % [specifier])
 
-  SlmToml(name, version, dependencies)
+  SlmToml(name, version, compiler?, dependencies)

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -8,11 +8,12 @@ defpackage slm/utils:
 
   import slm/file-utils
 
-public defn get-stanza-exe () -> String :
+public defn get-stanza-exe (compiler?:Maybe<String>) -> String :
   val ret = get-env("SLM_STANZA")
-  match(ret):
-    (x:String): trim(x)
-    (_:False): "stanza"
+  trim $ match(compiler?, ret):
+    (_, x:String): x
+    (x:One<String>, _): value(x)
+    (x:None, y:False): "stanza"
 
 public defn clear-color? (c: ColoredString) -> ColoredString:
   if not supports-color?():

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -8,6 +8,12 @@ defpackage slm/utils:
 
   import slm/file-utils
 
+public defn get-stanza-exe () -> String :
+  val ret = get-env("SLM_STANZA")
+  match(ret):
+    (x:String): trim(x)
+    (_:False): "stanza"
+
 public defn clear-color? (c: ColoredString) -> ColoredString:
   if not supports-color?():
     c $> clear


### PR DESCRIPTION
Closes JITX-7190

This allows the user to pass a differently named stanza executable via the `SLM_STANZA` environment variable. This allows the tool to build and work with `jstanza` for example.