### PR TITLE
[Refactor] Changed stanza.proj tree structure

### DIFF
--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -38,7 +38,6 @@ defn write-build-stanza-proj (dependencies: Tuple<Dependency>) -> False:
     for dep in dependencies do:
       val dep-path = get-cwd() $> parse-path $> relative-to-dir{_, dep $> /path}
       println(f, to-string(\<>include "%_/stanza.proj"<> % [dep-path]))
-    println(f, \<>include "../stanza.proj"<>)
 
 defn write-slm-lock-file (dependencies: Tuple<Dependency>) -> False:
   within f = open("slm.lock", false):
@@ -89,13 +88,17 @@ public defn build (cmd-args:CommandArgs) -> False:
   val build-args = get-build-args()
   debug("with build args '%,'" % [build-args])
 
-  val args = to-tuple $ cat-all([[stanza-exe, "build"], targ?, build-args, ["-pkg", "pkgs"]])
+  ; In general - we want all of the options for the project to be
+  ;  captured in the `stanza.proj` file - not as options passed to this command.
+  ;  Otherwise, the user will have to remember to pass `-pkg pkgs` on the command
+  ;  line to the `stanza build` if they want to run the compiler directly instead
+  ;  of through `slm`
+  val args = to-tuple $ cat-all([[stanza-exe, "build"], targ?, build-args])
   val vStr =  version(cfg)
   debug("Build Version: %_" % [vStr])
   val env-vars = ["SLM_BUILD_VERSION" => vStr]
   debug("Stanza: %," % [args])
   ProcessBuilder(args)
-    $> in-dir{_, slm-dir}
     $> with-env-vars{_, env-vars}
     $> build
     $> wait-process-throw-on-nonzero{_, "build failed!"}

--- a/src/commands/init.stanza
+++ b/src/commands/init.stanza
@@ -57,7 +57,8 @@ public defn init (cmd-args:CommandArgs) -> False:
 
   ; Create empty .slm directory structure
   create-dir(slm-dir-path)
-  create-dir(to-string("%_/pkgs/" % [slm-dir-path]))
+  val pkg-path = to-string("%_/pkgs/" % [slm-dir-path])
+  create-dir(pkg-path)
   create-dir(to-string("%_/deps/" % [slm-dir-path]))
   create-empty-file(to-string("%_/stanza.proj" % [slm-dir-path]))
 
@@ -76,13 +77,15 @@ public defn init (cmd-args:CommandArgs) -> False:
   val main-package = to-string("%_/main" % [project-name])
   val stanza-proj-path = to-string("%_/stanza.proj" % [project-dir])
   if not file-exists?(stanza-proj-path):
-    spit(stanza-proj-path, \<>include "src/stanza.proj"
+    spit(stanza-proj-path, \<>include ".slm/stanza.proj"  ; Dependencies
+include "src/stanza.proj"  ; Project Sources
 
 build main:
   inputs: %_
+  pkg: "%_"
   o: "%_"
 <>
-        % [main-package, project-name])
+        % [main-package, pkg-path, project-name])
 
   ; Create src/
   val project-src-dir = to-string("%_/src/" % [project-dir])

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -18,7 +18,7 @@ public defn repl (cmd-args:CommandArgs) -> False:
   val cfg = parse-slm-toml("slm.toml")
   val stanza-exe = get-stanza-exe(compiler?(cfg))
   val repl-args = get-repl-args()
-  val args = to-tuple $ cat-all([[stanza-exe, "repl"], repl-args, ["-pkg", "pkgs"]])
+  val args = to-tuple $ cat-all([[stanza-exe, "repl"], repl-args])
   val slm-dir = to-string("%_/.slm" % [get-cwd()])
 
   val vStr =  version(cfg)
@@ -27,7 +27,6 @@ public defn repl (cmd-args:CommandArgs) -> False:
   debug("Stanza: %," % [args])
 
   ProcessBuilder(args)
-    $> in-dir{_, slm-dir}
     $> with-env-vars{_, env-vars}
     $> build
     $> run-and-get-exit-code

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,3 +1,4 @@
+include ".slm/stanza.proj"
 include "src/stanza.proj"
 
 build main:


### PR DESCRIPTION
Closes JITX-7191

This commit changes the way that the `stanza.proj` files are created for projects.

In the old way, the `.slm/stanza.proj` was effectively the `root` stanza project file. This meant that to build, slm had to change directories to `.slm` and then run the `stanza build` there.

This caused a lot of complexity. It meant that I couldn't just run `stanza build` at the root directory. It also broke dependency resolution in vscode via the stanza language server.

This commit creates the root `stanza.proj` at the root of the project and then has the root `stanza.proj` import `.slm/stanza.proj`. The `.slm/stanza.proj` still manages all of the resolved dependencies of the project and abstracts that away from the end user. With this setup:

1.  The user can run `stanza build` from the root
2.  VSCode language server continues to work as expected.
3.  The structure of the project is a lot more clear.
4.  We can more easily define configuration options that affect the build without hiding them inside the `slm` executable. Specifically - I moved the `-pkg pkgs` command line option and put it  in the `stanza.proj` file for the `main` target. This means `stanza build` will just work.


# Notes

1.  We will need to update the dependent projects to match this new paradigm (stanza-toml, semver, maybe-utils, etc). This should not require a major lift - it should be just adding two lines to the `stanza.proj` file.
2.  With this setup, I can use `cmd-click` in vscode on dependencies in my project and they resolve to `.slm/deps/<project>/...`. That all seems to be working well. 
