### PR TITLE
Add Environment Variable Substitution in `PathDependency` & Bugfix

### DIFF
--- a/src/dependencies.stanza
+++ b/src/dependencies.stanza
@@ -34,37 +34,59 @@ defn parse-slm-lock-and-resolve-dependencies ():
       name(locked-dep) => match(locked-dep):
         (dep: LockedGitDependency):
           val locked-dep = GitDependency(name(dep), locator(dep), version(dep), hash(dep))
-          val slm-toml-dep = slm-toml-dependencies[name(dep)]
-          match(slm-toml-dep: GitDependency):
+          val slm-toml-dep? = get?(slm-toml-dependencies, name(dep))
+          match(slm-toml-dep?):
+            (slm-toml-dep:GitDependency):
               if not compatible?(version(slm-toml-dep), version(locked-dep)):
                 error("'%_' (version %_) specified in 'slm.toml'.\n\
                        This conflicts with locked version ('%_') from 'slm.lock'\n\
                        If you wish to use the version from your 'slm.toml', \
                        delete 'slm clean', then re-run this command."
                        % [name(dep), version(slm-toml-dep), version(locked-dep)])
-          else:
-            error("'%_' is specified as a path dependency in 'slm.toml'.\n\
-                   This conflicts with locked version ('%_') from 'slm.lock'\n\
-                   If you wish to use the version from your 'slm.toml', \
-                   delete 'slm clean', then re-run this command."
-                   % [name(dep), version(locked-dep)])
-          fetch-or-sync-at-hash(locked-dep)
-          locked-dep
+              else:
+                fetch-or-sync-at-hash(locked-dep)
+                locked-dep
+            (slm-toml-dep:PathDependency):
+              error("'%_' is specified as a path dependency in 'slm.toml'.\n\
+                    This conflicts with locked version ('%_') from 'slm.lock'\n\
+                    If you wish to use the version from your 'slm.toml', \
+                    delete 'slm clean', then re-run this command."
+                    % [name(dep), version(locked-dep)])
+            (x:False):
+              ; This dependency was found in the lock file but not in our slm.toml file.
+              ;  This likely means it is a "grand-child" or further decendent
+              ;  dependency. We just want to let it ride
+              ; TODO - It may also be a removed dependency. There is no way for me to
+              ;  distinguish between the two
+              locked-dep
         (dep: LockedPathDependency):
-          val path-dep = slm-toml-dependencies[name(dep)]
-          if path-dep is-not PathDependency:
-            error("'%_' is specified as a git dependency in 'slm.toml'.\n\
-                   This conflicts with locked (path) version from 'slm.lock'\n\
-                   If you wish to use the version from your 'slm.toml', \
-                   delete 'slm clean', then re-run this command."
-                   % [name(dep)])
-          path-dep
+          val slm-toml-dep = get?(slm-toml-dependencies, name(dep))
+          match(slm-toml-dep):
+            (git-dep:GitDependency):
+              error("'%_' is specified as a git dependency in 'slm.toml'.\n\
+                    This conflicts with locked (path) version from 'slm.lock'\n\
+                    If you wish to use the version from your 'slm.toml', \
+                    delete 'slm clean', then re-run this command."
+                    % [name(dep)])
+            (path-dep:PathDependency):
+              path-dep
+            (x:False):
+              ; This dependency was found in the lock file but was not found
+              ;  in our slm.toml file. This likely means it is a "grand-child"
+              ;  or further descendent dependency. This isn't a common case - but
+              ;  might happen during development.
+              ; TODO Current Code Structure makes it impossible to handle this case
+              error("'%_' is found in the 'slm.lock' file but not in 'slm.toml'. \
+                    It is likely a grandchild dependency that is included as a path.\
+                    We don't currently handle this case. Consider adding the\
+                    necessary path dependency to the local project's 'slm.toml'\
+                    to work around this short-coming.")
 
   for [name, dep] in pairs(slm-toml-dependencies) do:
     if get?(locked-dependencies, name) is False:
       error("'%_' (version '%_') specified in 'slm.toml' not found in 'slm.lock'.\n\
              If you wish to add a dependency to your 'slm.toml', \
-             delete 'slm clean', then re-run this command."
+             run 'slm clean', then re-run this command."
              % [name, version-string?(dep) $> value-or{_, path(dep)}])
 
   ; TODO warn user if `slm.toml` is newer than `slm.lock` so we can catch

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -63,5 +63,46 @@ defn parse-specifier (specifier: String) -> [String, SemanticVersion]:
     else:
       error("malformed specifier '%_'" % [specifier])
 
+
+; This function was shamelessly stolen from lbstanza:compiler/config.stanza
+; https://github.com/StanzaOrg/lbstanza/blob/0cbcd2ce7d8b1794e82624170a0a09d3053d0fb1/compiler/config.stanza#L298
+; Sadly - it is not public so I can't just invoke it directly.
+defn sub-curly (f:String -> String, s:String) -> String :
+  if index-of-char(s, '{') is False :
+    s
+  else :
+    val buffer = StringBuffer()
+
+    ;Iterate through the curlies
+    let loop (start:Int = 0) :
+      ;Determine curly bounds
+      val [i, j] = let :
+        val i = index-of-char(s, start to false, '{')
+        match(i:Int) :
+          [i, index-of-char(s, (i + 1) to false, '}')]
+        else : [i, false]
+      ;If there is a curly
+      match(i:Int, j:Int) :
+        ;Add string up to curly
+        if start < i :
+          add-all(buffer, s[start to i])
+        ;Add replacement
+        val replacement = f(s[(i + 1) through (j - 1)])
+        add-all(buffer, replacement)
+        ;Continue past } char
+        loop(j + 1)
+      else :
+        ;End of string, add the rest
+        if start < length(s) :
+          add-all(buffer, s[start to false])
+
+    ;Return spliced string
+    to-string(buffer)
+
+defn env-var-substitute (path:String) -> String:
+  within name = sub-curly(path):
+    get-env!(name)
+
 public defn parse-path-dependency (name: String, path: String) -> PathDependency:
-  PathDependency(name, path)
+  val path* = env-var-substitute(path)
+  PathDependency(name, path*)

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -91,7 +91,7 @@ forms:
 
 The github resolution is a String formatted as:
 
-dep-projet = "ORG/PROJECT|SEMVER"
+dep-project = "ORG/PROJECT|SEMVER"
 
  - dep-project = Name of the dependency we are resolving.
  - ORG = The Github Organization where the project can be found.
@@ -108,6 +108,15 @@ dep-project = { path = "/Full/Path/Here" }
 The 'path' attribute of this object makes reference to a file path
 on the local computer that is accessible through the filesystem.
 
+The string value of the 'path' attribute supports environment
+variable substitution with the following syntax:
+
+dep-project = { path = "{HOME}/src/path/here" }
+
+Where 'slm' will check the environment for the 'HOME' environment
+variable and directly substitute that string if found. If no environment
+variable by that name is found, this is an error and will cause the `slm`
+build to fail.
 
 <MSG>
 


### PR DESCRIPTION
Closes JITX-7205 and JITX-7192

This adds the ability to use environment variables in path dependency specifications.
It also fixes a bug where grand-children dependencies were not properly handled resulting in a crash.