### PR TITLE
Graceful Degrade on `git`

### DIFF
--- a/src/commands/init.stanza
+++ b/src/commands/init.stanza
@@ -116,7 +116,7 @@ main()
 
   ; Initialize Git repo in .git
   val git-dir = to-string("%_/.git/" % [project-dir])
-  if not file-exists?(git-dir):
+  if has-git?() and not file-exists?(git-dir):
     git-init(project-dir)
 
   println("slm: init: package `%_` initialized in `%_`"

--- a/src/commands/publish.stanza
+++ b/src/commands/publish.stanza
@@ -39,6 +39,9 @@ defn git-get-branch-remote? (branch: String) -> Maybe<String>:
   $> filter{_, {not empty?(_)}}
 
 public defn publish (cmd-args:CommandArgs) -> False:
+  if not has-git?() :
+    error("No `git` executable found on the path")
+
   ; What do we need to do?
   ;
   ; 1. Grab the user's version from their `slm.toml`. If `slm.toml` doesn't

--- a/src/dependencies.stanza
+++ b/src/dependencies.stanza
@@ -95,6 +95,9 @@ defn parse-slm-lock-and-resolve-dependencies ():
   to-tuple $ values $ locked-dependencies
 
 defn fetch-or-sync-at-hash (d: GitDependency) -> False:
+  if not has-git?() :
+    error("No `git` executable found on the path")
+
   if file-exists?(path(d)):
     sync-dependency-to-hash(d)
   else:

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -3,9 +3,47 @@ defpackage slm/git-utils:
   import collections
 
   import maybe-utils
+  import semver
 
   import slm/file-utils
   import slm/process-utils
+
+defn parse-git-version (msg:String) -> Maybe<SemanticVersion> :
+  val comps = split(msg, " ")
+  for comp in comps first:
+    parse-semver(comp)
+
+defn run-git-version () -> Maybe<SemanticVersion> :
+  try:
+    val p = ProcessBuilder(["git", "version"])
+      $> with-output
+      $> build
+
+    ; Evidently - you have to call `get-output` before `run` here
+    ;   Otherwise, it will throw an "Bad file descriptor" error.
+    val msg = get-output(p) $> trim
+    val code = run-and-get-exit-code(p)
+    if code == 0:
+      parse-git-version(msg)
+    else if code == 127:
+      ; This indicates that there is no `git` on the path:
+      None()
+    else:
+      println("Error checking 'git version': code = %_ \n %_" % [code, msg])
+      None()
+  catch (e:ProcessLaunchError):
+    ; Launch failure is synonymous with executable not found.
+    None()
+
+var git-vers:Maybe<SemanticVersion> = run-git-version()
+
+public defn git-version? () -> Maybe<SemanticVersion> :
+  git-vers
+
+public defn has-git? () -> True|False :
+  match(git-version?()):
+    (x:One<SemanticVersion>): true
+    (_:None): false
 
 public defn git-rev-parse (work-tree: String, rev: String) -> String:
   command-output-in-dir(work-tree, ["git", "rev-parse", "--verify", "--quiet", rev])


### PR DESCRIPTION
Closes JITX-7204

This PR adds the ability to check for the `git` executable before running any of functionality in slm that depend on `git`. 

`init` - silently doesn't run `git init` - project should be fully functional otherwise.
`build/repl` - Throws an error if it needs to try and resolve any `git` based dependencies. Other dependencies (path dependencies) should resolve without issue. 
`publish` -  Fails outright without a git binary.