### PR TITLE
Add the `add` and `remove` commands for dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .slm/
 build/
 slm
+test-pkgs/
+slm-tests
+.vscode/

--- a/slm.lock
+++ b/slm.lock
@@ -1,4 +1,4 @@
-semver={locator="StanzaOrg/semver",version="0.1.4",hash="03fde773b94cc2f86cbafbdc7f879f2d486b5613"}
+semver={locator="StanzaOrg/semver",version="0.1.6",hash="13f3eba0e1cfc5bf926134ef8b43bd7d07981ea4"}
 term-colors={locator="StanzaOrg/term-colors",version="0.1.1",hash="1d394dce2cb079a4c8d5dccbbede63b0f894eac4"}
 stanza-toml={locator="StanzaOrg/stanza-toml",version="0.3.4",hash="3ea19b9dd28ee4edd7903dbd105cd202c7d27e91"}
 maybe-utils={locator="StanzaOrg/maybe-utils",version="0.1.4",hash="9a364ff7b7e041451cdf29c9dafed945230868e4"}

--- a/slm.toml
+++ b/slm.toml
@@ -3,6 +3,6 @@ version = "0.3.2"
 
 [dependencies]
 stanza-toml = "StanzaOrg/stanza-toml|0.3.4"
-semver      = "StanzaOrg/semver|0.1.4"
+semver      = "StanzaOrg/semver|0.1.6"
 maybe-utils = "StanzaOrg/maybe-utils|0.1.4"
 term-colors = "StanzaOrg/term-colors|0.1.1"

--- a/src/commands.stanza
+++ b/src/commands.stanza
@@ -1,4 +1,6 @@
 defpackage slm/commands:
+  forward slm/commands/add with:
+    only => (setup-add-cmd)
   forward slm/commands/build with:
     only => (setup-build-cmd)
   forward slm/commands/clean with:

--- a/src/commands.stanza
+++ b/src/commands.stanza
@@ -9,6 +9,8 @@ defpackage slm/commands:
     only => (setup-init-cmd)
   forward slm/commands/publish with:
     only => (setup-publish-cmd)
+  forward slm/commands/remove with:
+    only => (setup-remove-cmd)
   forward slm/commands/repl with:
     only => (setup-repl-cmd)
   forward slm/commands/version with:

--- a/src/commands/add.stanza
+++ b/src/commands/add.stanza
@@ -1,0 +1,264 @@
+defpackage slm/commands/add:
+  import core
+  import collections
+  import arg-parser
+
+  import semver
+  import maybe-utils
+
+  import slm/flags
+  import slm/toml
+  import slm/dependency
+  import slm/errors
+  import slm/file-utils
+  import slm/git-utils
+  import slm/utils
+  import slm/logging
+
+defn convert-version-spec (arg:String|False) -> Maybe<SemanticVersion> :
+  match(arg):
+    (x:String):
+      ; If the user doesn't pass a valid version string - I want to
+      ;  catch it here before proceeding further. I don't want it
+      ;  treated the same as "No '-version' provided in the command line args"
+      One $ value-or-throw{_, InvalidVersionError(x)} $ parse-semver(x)
+    (_): None()
+
+defn cli-add-dependency (cmd-args:CommandArgs) -> False :
+  val git-path = get?(cmd-args, "git", false)
+  val fs-path = get?(cmd-args, "path", false)
+
+  val name? = to-maybe $ get?(cmd-args, "name", false)
+  val version-spec? =  convert-version-spec $ get?(cmd-args, "version", false)
+  val force = get?(cmd-args, "force", false)
+  val dry-run? = get?(cmd-args, "dry-run", false)
+
+  debug("Add Parameters:")
+  val paramTable = [
+    ["git", git-path]
+    ["path", git-path]
+    ["name", name?]
+    ["version", version-spec?]
+    ["force", force]
+    ["dry-run", dry-run?]
+  ]
+  for kvp in paramTable do:
+    debug("\t%_ = %_" % kvp)
+
+  val cfg = parse-slm-toml(SLM_TOML_NAME)
+
+  val cfg* = match(git-path, fs-path):
+    (x:String, y:String):
+      error("Flags '-git' and '-path' are mutually exclusive!")
+    (x:String, y:False):
+      add-git-dependency(cfg, x, version-spec?, name-override = name?, force = force )
+    (x:False, y:String):
+      add-path-dependency(cfg, y, name-override = name?, force = force)
+    (x:False, y:False):
+      error("The 'add' command expects either a '-path' or '-git' argument. Neither were provided.")
+
+  debug("-- Start New File Write --")
+
+  if dry-run?:
+    val o = current-output-stream()
+    write(o, cfg*)
+  else:
+    within f = open(SLM_TOML_NAME, false):
+      write(f, cfg*)
+
+  debug("-- New File Write Complete --")
+
+defn extract-name (path:String, name-override:Maybe<String>) -> String :
+  match(name-override):
+    (override:One<String>): value(override)
+    (_:None):
+      val [org, repo-name] = split-filepath(path)
+      repo-name
+
+defn remove-dependency (existing:Maybe<Dependency>, deps:HashTable<String, Dependency>, force:True|False) -> False:
+  match(existing:One):
+    val dep = value(existing)
+    if not force:
+      throw $ DependencyAlreadyExistsError(name(dep))
+    else:
+      if remove(deps, name(dep)):
+        debug("Removed Existing Dep: %_" % [dep])
+
+public defn add-git-dependency (
+  cfg:SlmToml,
+  path:String,
+  version-spec?:Maybe<SemanticVersion>
+  --
+  name-override:Maybe<String> = None(),
+  force:True|False = false
+  ) -> SlmToml :
+
+  debug("Adding new git dependency")
+
+  val name = extract-name(path, name-override)
+
+  ; Check if a dependency by this name already exists in the
+  ;   repo configs.
+  val existing = find-dependency(cfg, name)
+
+  val deps = to-hashtable<String, Dependency>( dependencies(cfg) )
+  remove-dependency(existing, deps, force)
+
+  val version-spec = match(version-spec?):
+    (_:None):
+      ; we need to query the repo for the lastest tag
+      ;   in the repository.
+      if not has-git?():
+        val PATH = to-maybe $ get-env("PATH")
+        throw $ GitNotFoundError(PATH)
+
+      ; We need at least this version to use `ls-remote`.
+      val exp-git = SemanticVersion(2, 28, 0)
+      if not check-git-version(exp-git) :
+        throw $ GitVersionError(git-version?(), exp-git)
+
+      val url = full-url-from-locator(path)
+      val tags = git-remote-tag-refs(url)
+      debug("Retrieved Tags:")
+      debug( string-join(keys(tags), "\n") )
+      val v-table = to-version-table(tags)
+      ; We want to find the latest tagged version of this package
+      ;  and add that version to the dependency list.
+      val versions = to-vector<SemanticVersion> $ keys(v-table)
+      qsort!(versions)
+      debug("Retrieved Versions:")
+      debug( string-join(versions, "\n") )
+      val latest-version? = last?(versions)
+      value-or-throw{_, NoTaggedVersionsError(name)} $ last?(versions)
+    (x:One<SemanticVersion>): value(x)
+
+  deps[name] = GitDependency(name, path, version-spec, "")
+
+  sub-deps(cfg, deps)
+
+
+public defn add-path-dependency (
+  cfg:SlmToml,
+  path:String
+  --
+  name-override:Maybe<String> = None(),
+  force:True|False = false
+  ) -> SlmToml:
+
+  debug("Adding new path dependency")
+
+  val name = extract-name(path, name-override)
+
+  val existing = find-dependency(cfg, name)
+
+  val deps = to-hashtable<String, Dependency>( dependencies(cfg) )
+  remove-dependency(existing, deps, force)
+
+  deps[name] = PathDependency(name, path)
+
+  sub-deps(cfg, deps)
+
+val ADD-MSG = \<MSG>
+The 'add' command will append a new dependency to the 'slm.toml' file
+of the current project.
+
+If the project already contains a reference to this dependency, then
+the 'add' command will do nothing.
+
+Examples:
+
+Add a new Github dependency at the latest tag:
+
+  $> slm add -git StanzaOrg/stanza-toml
+
+  Resolves to:
+
+  """
+  [dependencies]
+  stanza-toml = "StanzaOrg/stanza-toml|0.3.5"
+  """
+
+Add a new Github dependency at a particular version
+
+  $> slm add -git StanzaOrg/stanza-toml -version 0.3.4
+
+  Resolves to:
+
+  """
+  [dependencies]
+  stanza-toml = "StanzaOrg/stanza-toml|0.3.4"
+  """
+
+Add a new Path Dependency
+
+  $> slm add -path ~/src/semver
+
+  Resolves to:
+
+  """
+  [dependencies]
+  semver = { path= "/home/john/src/semver" }
+  """
+
+Add a new Path Dependency with name override
+
+  $> slm add -name stanza-toml -path ~/src/stanza-toml-v2
+
+  Resolves to:
+
+  """
+  [dependencies]
+  stanza-toml = { path= "/home/john/src/stanza-toml-v2" }
+  """
+
+<MSG>
+
+val GIT-FLAG = \<MSG>
+Set the org/name path for a new 'GitDependency' to be added to the 'slm.toml' file
+of this project. By default, the basename is extracted as the dependency name. Use
+the '-name' flag to override this behavior.
+<MSG>
+
+val PATH-FLAG = \<MSG>
+Set the path for a new 'PathDependency' to be added to the 'slm.toml' file of this project.
+This path can be relative or absolute path to a project directory. By default, the basename
+is extracted as the dependency name. Use the '-name' flag to override this behavior.
+<MSG>
+
+val NAME-FLAG = \<MSG>
+This flag sets the name for the added dependency. This can be used to override the
+name extracted from the basename of the specified path or Github project.
+<MSG>
+
+; TODO - Updated here to add behavior for `PathDependency' objects
+;  when we get the version spec for path deps implemented.
+val VERSION-FLAG = \<MSG>
+This flag sets the desired version for the added dependency. If the '-version'
+flag is not provided, then the latest tagged version of that dependency will
+be used by default.
+<MSG>
+
+val FORCE-FLAG = \<MSG>
+This flag will force 'slm' to add a dependency to the 'slm.toml'. This is useful
+for cases where you want to add a 'PathDependency' that overrides an existing
+'GitDependency'. If an existing dependency with a matching 'name' is found, then
+that dependency will be dropped from the 'slm.toml' before the new overriding
+dependency is added.
+<MSG>
+
+val DRY-RUN-FLAG = \<MSG>
+This flag will cause 'slm' to do all of the checks and operations to perform
+an 'add' operation - but it won't actually change the 'slm.toml' file of the
+project. It will output the resultant changes to std-out for inspection.
+<MSG>
+
+public defn setup-add-cmd () -> Command :
+  val addFlags = [
+    Flag("git", OneFlag, OptionalFlag, GIT-FLAG)
+    Flag("path", OneFlag, OptionalFlag, PATH-FLAG)
+    Flag("name", OneFlag, OptionalFlag, NAME-FLAG)
+    Flag("version", OneFlag, OptionalFlag, VERSION-FLAG)
+    Flag("force", ZeroFlag, OptionalFlag, FORCE-FLAG)
+    Flag("dry-run", ZeroFlag, OptionalFlag, DRY-RUN-FLAG)
+  ]
+  Command("add", ZeroArg, false, addFlags, ADD-MSG, cli-add-dependency)

--- a/src/commands/init.stanza
+++ b/src/commands/init.stanza
@@ -140,7 +140,7 @@ public defn init (cmd-args:CommandArgs) -> False:
   false
 
 val INIT-MSG = \<MSG>
-The 'init' command will initial a 'slm' package structure into
+The 'init' command will initialize a 'slm' package structure into
 the passed directory.
 
 If there are existing files present in the new project directory,

--- a/src/commands/remove.stanza
+++ b/src/commands/remove.stanza
@@ -1,0 +1,80 @@
+defpackage slm/commands/remove:
+  import core
+  import collections
+  import arg-parser
+
+  import slm/flags
+  import slm/toml
+  import slm/dependency
+  import slm/logging
+  import slm/errors
+  import slm/file-utils
+
+public defn cli-remove-dependency (cmd-args:CommandArgs) -> False :
+  val targets = args(cmd-args)
+  val dry-run? = get?(cmd-args, "dry-run", false)
+
+  val cfg = parse-slm-toml(SLM_TOML_NAME)
+
+  val cfg* = remove-dependency(cfg, targets)
+
+  debug("-- Start New File Write --")
+
+  if dry-run?:
+    val o = current-output-stream()
+    write(o, cfg*)
+  else:
+    within f = open(SLM_TOML_NAME, false):
+      write(f, cfg*)
+
+  debug("-- New File Write Complete --")
+
+
+public defn remove-dependency (
+  cfg:SlmToml,
+  targets:Tuple<String>
+  ) -> SlmToml:
+
+  val deps = to-hashtable<String, Dependency> $ dependencies(cfg)
+
+  val dep-names = to-tuple $ keys(deps)
+
+  ; Check that all of the deps we want to remove actually exist
+  val not-found = to-tuple $ for target in targets seq? :
+    if not contains?(dep-names, target): One(target)
+    else: None()
+
+  if length(not-found) > 0:
+    throw $ DependencyNotFoundError(not-found)
+
+  for target in targets do:
+    remove(deps, target)
+
+  sub-deps(cfg, deps)
+
+val RM-MSG = \<MSG>
+Remove one or more dependencies from the 'slm.toml' file. The names
+must match explicitly to one of the dependencies in the `[dependencies]`
+table in the `slm.toml`. If any name does not match, this command will
+fail.
+
+It is a good idea to run 'slm clean' after this operation to remove any
+trailing dependencies.
+<MSG>
+
+val RM-ARG-MSG = \<MSG>
+The remove command accepts one or more target dependency names for removal.
+<MSG>
+
+val DRY-RUN-FLAG = \<MSG>
+This flag will cause 'slm' to do all of the checks and operations to perform
+an 'remove' operation - but it won't actually change the 'slm.toml' file of the
+project. It will output the resultant changes to std-out for inspection.
+<MSG>
+
+public defn setup-remove-cmd () -> Command :
+  val rmFlags = [
+    Flag("dry-run", ZeroFlag, OptionalFlag, DRY-RUN-FLAG)
+  ]
+
+  Command("remove", AtLeastOneArg, RM-ARG-MSG, rmFlags, RM-MSG, cli-remove-dependency)

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -20,6 +20,9 @@ public defstruct PathDependency <: Dependency:
   name: String with: (as-method => true)
   path: String with: (as-method => true)
 
+defmethod print (o:OutputStream, d:PathDependency) :
+  print(o, "%_ = { path = \"%_\" }" % [name(d), path(d)])
+
 ; Dependencies specified by Git locator/version (e.g. `foo = "myorg/myuser|1.0.0"`)
 public defstruct GitDependency <: Dependency:
   name: String with: (as-method => true)
@@ -32,6 +35,9 @@ defmethod path (d: GitDependency):
 
 defmethod version-string? (d: GitDependency) -> One<String>:
   One(version-string(d))
+
+defmethod print (o:OutputStream, d:GitDependency) :
+  print(o, "%_ = \"%_|%_\"" % [name(d), locator(d), version-string(d)])
 
 public defn version-string (d: GitDependency) -> String:
   to-string(version(d))

--- a/src/errors.stanza
+++ b/src/errors.stanza
@@ -39,3 +39,10 @@ public defstruct DependencyAlreadyExistsError <: Exception:
 public defmethod print (o:OutputStream, e:DependencyAlreadyExistsError):
   val msg = "Attempting add dependency '%_' but a pre-existing dependency with this name already exists!" % [name(e)]
   print(o, msg)
+
+public defstruct DependencyNotFoundError <: Exception :
+  targets:Tuple<String>
+
+public defmethod print (o:OutputStream, e:DependencyNotFoundError):
+  val msg = "The following dependencies were not found in the dependency table: %," % [targets(e)]
+  print(o, msg)

--- a/src/errors.stanza
+++ b/src/errors.stanza
@@ -1,0 +1,41 @@
+defpackage slm/errors:
+  import core
+  import semver
+
+public defstruct GitNotFoundError <: Exception :
+  PATH:Maybe<String>
+
+public defmethod print (o:OutputStream, e:GitNotFoundError):
+  val msg = \<MSG>The 'git' binary was not found on $PATH:
+  %_
+  <MSG>
+  print(o, msg % [PATH(e)])
+
+public defstruct GitVersionError <: Exception:
+  git-version:Maybe<SemanticVersion>
+  required-version:SemanticVersion
+
+public defmethod print (o:OutputStream, e:GitVersionError):
+  val msg = "The 'git' binary reports version '%_' but this command requires at least version '%_'" % [git-version(e), required-version(e)]
+  print(o, msg)
+
+public defstruct InvalidVersionError <: Exception:
+  raw-str:String
+
+public defmethod print (o:OutputStream, e:InvalidVersionError):
+  val msg = "Invalid Version: Failed to convert '%_' to Semantic Version" % [raw-str(e)]
+  print(o, msg)
+
+public defstruct NoTaggedVersionsError <: Exception :
+  name:String
+
+public defmethod print (o:OutputStream, e:NoTaggedVersionsError):
+  val msg = "No Tagged Versions found in dependency '%_' repository." % [name(e)]
+  print(o, msg)
+
+public defstruct DependencyAlreadyExistsError <: Exception:
+  name:String
+
+public defmethod print (o:OutputStream, e:DependencyAlreadyExistsError):
+  val msg = "Attempting add dependency '%_' but a pre-existing dependency with this name already exists!" % [name(e)]
+  print(o, msg)

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -61,7 +61,15 @@ public defn git-rev-parse! (work-tree: String, rev: String) -> String:
   ret
 
 public defn git-remote-tag-refs (remote: String) -> HashTable<String, String>:
-  val output = call-system-and-get-output("git", ["git", "ls-remote", "-q", "--tags", remote])
+  val p = ProcessBuilder(["git", "ls-remote", "-q", "--tags", remote])
+    $> with-output
+    $> build
+
+  val output = get-output(p) $> trim
+  val code = run-and-get-exit-code(p)
+  if code != 0:
+    throw $ Exception("Failed to list tags from remote")
+
   val pairs = to-tuple $ split(output, "\n")
   to-hashtable<String, String> $ seq?{_, pairs} $ fn (line):
     val elements = to-tuple $ split(line, "\t")
@@ -69,7 +77,6 @@ public defn git-remote-tag-refs (remote: String) -> HashTable<String, String>:
       One(elements[1] => elements[0])
     else:
       None()
-
 
 doc: \<DOC>
 Convert the `Tag` => Git Hash table to a SemVer => Hash table.

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -5,6 +5,7 @@ defpackage slm/git-utils:
   import maybe-utils
   import semver
 
+  import slm/utils
   import slm/file-utils
   import slm/process-utils
 
@@ -45,6 +46,11 @@ public defn has-git? () -> True|False :
     (x:One<SemanticVersion>): true
     (_:None): false
 
+public defn check-git-version (required:SemanticVersion) -> True|False :
+  match(git-version?()):
+    (_:None): false
+    (curr:One<SemanticVersion>): value(curr) >= required
+
 public defn git-rev-parse (work-tree: String, rev: String) -> String:
   command-output-in-dir(work-tree, ["git", "rev-parse", "--verify", "--quiet", rev])
 
@@ -63,6 +69,27 @@ public defn git-remote-tag-refs (remote: String) -> HashTable<String, String>:
       One(elements[1] => elements[0])
     else:
       None()
+
+
+doc: \<DOC>
+Convert the `Tag` => Git Hash table to a SemVer => Hash table.
+
+This takes the output of `git-remote-tag-refs` and converts it into
+a more useable format for querying the versions.
+<DOC>
+public defn to-version-table (tag-hash:HashTable<String,String>) -> HashTable<SemanticVersion, String> :
+  to-hashtable<SemanticVersion, String> $ for kvp in tag-hash seq? :
+    val [tag, hash-str] = [key(kvp), value(kvp)]
+    val comps = split-any(tag, "^~:")
+    val tagPath = comps[0]
+    val [root, tagName] = split-filepath(tagPath)
+    ; We expect tagName to be in the form `v0.3.2` or something similar.
+    val tagName* = tagName[1 to false]
+    val version? = parse-semver(tagName*)
+    match(version?):
+      (x:None): x
+      (x:One<SemanticVersion>):
+        One(value(x) => hash-str)
 
 public defn run-git-command-in-dir (work-tree?: Maybe<String>, args0: Tuple<String>) -> Int:
   val args = to-tuple $ cat(["git"], args0)

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -16,6 +16,7 @@ defn setup-opts ():
   add(CMDS, setup-clean-cmd())
   add(CMDS, setup-init-cmd())
   add(CMDS, setup-publish-cmd())
+  add(CMDS, setup-remove-cmd())
   add(CMDS, setup-repl-cmd())
   add(CMDS, setup-version-cmd())
 

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -11,6 +11,7 @@ defpackage slm/main:
 val CMDS = Vector<Command>()
 
 defn setup-opts ():
+  add(CMDS, setup-add-cmd())
   add(CMDS, setup-build-cmd())
   add(CMDS, setup-clean-cmd())
   add(CMDS, setup-init-cmd())

--- a/src/toml.stanza
+++ b/src/toml.stanza
@@ -16,7 +16,7 @@ public defstruct SlmToml:
   name: String
   version: String
   compiler?: Maybe<String>
-  dependencies: HashTable<String, Dependency>
+  dependencies: HashTable<String, Dependency> with: (updater => sub-deps)
 
 public defn parse-slm-toml (path: String) -> SlmToml:
   val table = path $> parse-file $> table
@@ -37,3 +37,21 @@ public defn parse-slm-toml (path: String) -> SlmToml:
                 % [specifier])
 
   SlmToml(name, version, compiler?, dependencies)
+
+doc: \<DOC>
+Output the SlmToml config as a valid TOML file.
+<DOC>
+public defmethod write (o:OutputStream, cfg:SlmToml) :
+  println(o, "name = \"%_\"" % [name(cfg)])
+  println(o, "version = \"%_\"" % [version(cfg)])
+  match(compiler?(cfg)):
+    (x:One<String>): println(o, "compiler = \"%_\"" % [x] )
+    (_:None): false
+  println(o, "[dependencies]")
+  for dep in values(dependencies(cfg)) do:
+    println(o, dep)
+
+public defn find-dependency (cfg:SlmToml, name:String) -> Maybe<Dependency> :
+  val deps = dependencies(cfg)
+  for dep-name in keys(deps) first :
+    One(deps[name]) when name == dep-name else None()

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -66,3 +66,25 @@ stanza full-qualified package paths.
 public defn path-join (parts:String ...) -> String :
   string-join(parts, "/")
 
+doc: \<DOC>
+Given a string - split it on any of the passed characters.
+
+The characters in the `splitters` are ordered. The first
+one that succeeds will be returned
+
+Example:
+
+val ret = split-any("asdf#qwer", "^#")
+#EXPECT(ret == ["asdf", "qwer"])
+
+val ret = split-any("asdf:qwer", "^#")
+#EXPECT(ret == ["asdf:qwer"])
+
+<DOC>
+public defn split-any (s:String, splitters:String) -> Tuple<String> :
+  label<Tuple<String>> return:
+    for splitter in splitters do:
+      val comps = to-tuple $ split(s, to-string(splitter), 2)
+      if length(comps) > 1 :
+        return(comps)
+    return([s])

--- a/stanza.proj
+++ b/stanza.proj
@@ -1,7 +1,17 @@
 include? ".slm/stanza.proj"
 
 packages slm/* defined-in "src/"
+packages slm/tests/* defined-in "tests/"
 
 build main:
-    inputs: slm/main
-    o: "slm"
+  inputs: slm/main
+  pkg: ".slm/pkgs"
+  o: "slm"
+
+build-test tests:
+  inputs:
+    slm/tests/git-utils
+    slm/tests/utils
+    slm/tests/toml
+  pkg: "test-pkgs"
+  o: "slm-tests"

--- a/stanza.proj
+++ b/stanza.proj
@@ -13,5 +13,6 @@ build-test tests:
     slm/tests/git-utils
     slm/tests/utils
     slm/tests/toml
+    slm/tests/commands/add
   pkg: "test-pkgs"
   o: "slm-tests"

--- a/stanza.proj
+++ b/stanza.proj
@@ -14,5 +14,6 @@ build-test tests:
     slm/tests/utils
     slm/tests/toml
     slm/tests/commands/add
+    slm/tests/commands/remove
   pkg: "test-pkgs"
   o: "slm-tests"

--- a/tests/commands/add.stanza
+++ b/tests/commands/add.stanza
@@ -1,0 +1,173 @@
+#use-added-syntax(tests)
+defpackage slm/tests/commands/add:
+  import core
+  import collections
+
+  import semver
+
+  import slm/commands/add
+  import slm/toml
+  import slm/dependency
+
+  import slm/tests/test-tools
+
+deftest(add-cmd) test-add-git-basic:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.2",
+    None(),
+    to-hashtable<String, Dependency>([])
+  )
+
+  val uut = add-git-dependency(input, "StanzaOrg/stanza-toml", One $ SemanticVersion(0,3,2))
+
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.2" )
+  #EXPECT( compiler?(uut) == None() )
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  #EXPECT( length(names) == 1 )
+  #EXPECT( names[0] == "stanza-toml" )
+
+  val dep = deps["stanza-toml"] as GitDependency
+  #EXPECT(name(dep) == "stanza-toml")
+  #EXPECT(locator(dep) == "StanzaOrg/stanza-toml")
+  #EXPECT(version(dep) == SemanticVersion(0,3,2))
+
+
+deftest(add-cmd) test-add-git-existing:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.2",
+    None(),
+    to-hashtable<String, Dependency>([
+      "stanza-toml" => GitDependency("stanza-toml", "StanzaOrg/stanza-toml", SemanticVersion(0,3,1), "")
+    ])
+  )
+
+  defn attempt-add () :
+    ; Without Force - this should fail.
+    add-git-dependency(input, "StanzaOrg/stanza-toml", One $ SemanticVersion(0,3,2))
+
+  val msg = expect-throw(attempt-add)
+
+  #EXPECT(prefix?(value!(msg), "Attempting add dependency 'stanza-toml' but a pre-existing dependency"))
+
+deftest(add-cmd) test-add-git-existing-force:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.2",
+    None(),
+    to-hashtable<String, Dependency>([
+      "stanza-toml" => GitDependency("stanza-toml", "StanzaOrg/stanza-toml", SemanticVersion(0,3,1), "")
+    ])
+  )
+
+    ; Force should cause this to complete successfully
+  val uut = add-git-dependency(input, "StanzaOrg/stanza-toml", One $ SemanticVersion(0,3,2), force = true)
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.2" )
+  #EXPECT( compiler?(uut) == None() )
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  #EXPECT( length(names) == 1 )
+  #EXPECT( names[0] == "stanza-toml" )
+
+  val dep = deps["stanza-toml"] as GitDependency
+  #EXPECT(name(dep) == "stanza-toml")
+  #EXPECT(locator(dep) == "StanzaOrg/stanza-toml")
+  #EXPECT(version(dep) == SemanticVersion(0,3,2))
+
+
+deftest(add-cmd) test-add-git-name-override:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.2",
+    None(),
+    to-hashtable<String, Dependency>([])
+  )
+
+  val uut = add-git-dependency(input, "StanzaOrg/stanza-toml", One $ SemanticVersion(0,3,2), name-override = One("toml2"))
+
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.2" )
+  #EXPECT( compiler?(uut) == None() )
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  #EXPECT( length(names) == 1 )
+  #EXPECT( names[0] == "toml2" )
+
+  val dep = deps["toml2"] as GitDependency
+  #EXPECT(name(dep) == "toml2")
+  #EXPECT(locator(dep) == "StanzaOrg/stanza-toml")
+  #EXPECT(version(dep) == SemanticVersion(0,3,2))
+
+deftest(add-cmd) test-add-path-basic:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.2",
+    None(),
+    to-hashtable<String, Dependency>([])
+  )
+
+  val uut = add-path-dependency(input, "/Users/ted/src/stanza-toml")
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.2" )
+  #EXPECT( compiler?(uut) == None() )
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  #EXPECT( length(names) == 1 )
+  #EXPECT( names[0] == "stanza-toml" )
+
+  val dep = deps["stanza-toml"] as PathDependency
+  #EXPECT(name(dep) == "stanza-toml")
+  #EXPECT(path(dep) == "/Users/ted/src/stanza-toml")
+
+deftest(add-cmd) test-add-path-name-override:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.2",
+    None(),
+    to-hashtable<String, Dependency>([
+      "maybe-utils" => GitDependency("maybe-utils", "StanzaOrg/maybe-utils", SemanticVersion(0,1,4), "")
+      "semver" => GitDependency("semver", "StanzaOrg/semver", SemanticVersion(0,1,2), "")
+    ])
+  )
+
+  val uut = add-path-dependency(input, "/Users/ted/src/stanza-toml", name-override = One("toml-extreme"))
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.2" )
+  #EXPECT( compiler?(uut) == None() )
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  #EXPECT( length(names) == 3 )
+
+  val dep = deps["toml-extreme"] as PathDependency
+  #EXPECT(name(dep) == "toml-extreme")
+  #EXPECT(path(dep) == "/Users/ted/src/stanza-toml")
+
+  var gdep = deps["maybe-utils"] as GitDependency
+  #EXPECT(name(gdep) == "maybe-utils")
+  #EXPECT(locator(gdep) == "StanzaOrg/maybe-utils")
+  #EXPECT(version(gdep) == SemanticVersion(0,1,4))
+
+  gdep = deps["semver"] as GitDependency
+  #EXPECT(name(gdep) == "semver")
+  #EXPECT(locator(gdep) == "StanzaOrg/semver")
+  #EXPECT(version(gdep) == SemanticVersion(0,1,2))

--- a/tests/commands/remove.stanza
+++ b/tests/commands/remove.stanza
@@ -1,0 +1,129 @@
+#use-added-syntax(tests)
+defpackage slm/tests/commands/remove:
+  import core
+  import collections
+
+  import semver
+
+  import slm/commands/remove
+  import slm/toml
+  import slm/dependency
+
+  import slm/tests/test-tools
+
+deftest(rm-cmd) test-remove-basic:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.3",
+    One("jstanza")
+    to-hashtable<String, Dependency>([
+      "stanza-toml" => GitDependency("stanza-toml", "StanzaOrg/stanza-toml", SemanticVersion(0,3,1), "")
+    ])
+  )
+
+  val uut = remove-dependency(input, ["stanza-toml"])
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.3" )
+  #EXPECT( compiler?(uut) == One("jstanza"))
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  #EXPECT( length(names) == 0 )
+
+
+deftest(rm-cmd) test-remove-not-found:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.3",
+    None(),
+    to-hashtable<String, Dependency>([])
+  )
+
+  defn attempt-remove () :
+    remove-dependency(input, ["stanza-toml"])
+
+  val msg = expect-throw(attempt-remove)
+  #EXPECT(prefix?(value!(msg), "The following dependencies were not found"))
+
+
+deftest(rm-cmd) test-remove-with-others:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.3",
+    One("jstanza")
+    to-hashtable<String, Dependency>([
+      "stanza-toml" => GitDependency("stanza-toml", "StanzaOrg/stanza-toml", SemanticVersion(0,3,1), "")
+      "semver" => GitDependency("semver", "StanzaOrg/semver", SemanticVersion(0,1,4), "")
+      "maybe-utils" => GitDependency("maybe-utils", "StanzaOrg/maybe-utils", SemanticVersion(0,1,5), "")
+      "scooby-doo" => PathDependency("scooby-doo", "/where/are/you")
+    ])
+  )
+
+  val uut = remove-dependency(input, ["semver"])
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.3" )
+  #EXPECT( compiler?(uut) == One("jstanza"))
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  val expNames = ["stanza-toml", "maybe-utils", "scooby-doo"]
+  #EXPECT( length(names) == length(expNames) )
+
+  for name in names do:
+    #EXPECT(contains?(expNames, name))
+
+deftest(rm-cmd) test-remove-multiple:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.3",
+    One("jstanza")
+    to-hashtable<String, Dependency>([
+      "stanza-toml" => GitDependency("stanza-toml", "StanzaOrg/stanza-toml", SemanticVersion(0,3,1), "")
+      "semver" => GitDependency("semver", "StanzaOrg/semver", SemanticVersion(0,1,4), "")
+      "maybe-utils" => GitDependency("maybe-utils", "StanzaOrg/maybe-utils", SemanticVersion(0,1,5), "")
+      "scooby-doo" => PathDependency("scooby-doo", "/where/are/you")
+    ])
+  )
+
+  val uut = remove-dependency(input, ["semver", "scooby-doo"])
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.3" )
+  #EXPECT( compiler?(uut) == One("jstanza"))
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  val expNames = ["stanza-toml", "maybe-utils"]
+  #EXPECT( length(names) == length(expNames) )
+
+  for name in names do:
+    #EXPECT(contains?(expNames, name))
+
+
+deftest(rm-cmd) test-remove-multiple-with-fail:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.3",
+    One("jstanza")
+    to-hashtable<String, Dependency>([
+      "stanza-toml" => GitDependency("stanza-toml", "StanzaOrg/stanza-toml", SemanticVersion(0,3,1), "")
+      "semver" => GitDependency("semver", "StanzaOrg/semver", SemanticVersion(0,1,4), "")
+      "maybe-utils" => GitDependency("maybe-utils", "StanzaOrg/maybe-utils", SemanticVersion(0,1,5), "")
+      "scooby-doo" => PathDependency("scooby-doo", "/where/are/you")
+    ])
+  )
+
+  defn attempt-remove ():
+    remove-dependency(input, ["semver", "scooby-doo", "not-existing"])
+
+  val msg = expect-throw(attempt-remove)
+
+  #EXPECT(prefix?(value!(msg), "The following dependencies were not found"))
+

--- a/tests/data/test.toml
+++ b/tests/data/test.toml
@@ -1,0 +1,7 @@
+name = "test-slm"
+version = "0.2.1"
+compiler = "jstanza"
+[dependencies]
+stanza-toml = "StanzaOrg/stanza-toml|1.2.3"
+sqlite = { path = "/home/john/src/sqlite" }
+test-env = { path = "{TEST_VAR}/asdf" }

--- a/tests/git-utils.stanza
+++ b/tests/git-utils.stanza
@@ -1,0 +1,32 @@
+#use-added-syntax(tests)
+defpackage slm/tests/git-utils:
+  import core
+  import collections
+
+  import semver
+
+  import slm/git-utils
+
+deftest(git-utils) test-to-version-table:
+
+  val inputvec = to-hashtable<String, String>([
+    "refs/tags/v0.1.0" => "0001",
+    "refs/tags/v0.2.0" => "0002",
+    "refs/tags/v0.2.1^{}" => "0003",
+    "refs/tags/v0.2.2^{}" => "0004",
+    "refs/tags/cja_test" => "0005",   ; This should get filtered out.
+  ])
+
+  val obs = to-version-table(inputvec)
+
+  val exp = to-hashtable<SemanticVersion, String>([
+    SemanticVersion(0, 1, 0) => "0001",
+    SemanticVersion(0, 2, 0) => "0002",
+    SemanticVersion(0, 2, 1) => "0003",
+    SemanticVersion(0, 2, 2) => "0004",
+  ])
+
+  #EXPECT(length(obs) == length(exp))
+  for k in keys(exp) do:
+    #EXPECT(obs[k] == exp[k])
+

--- a/tests/test-tools.stanza
+++ b/tests/test-tools.stanza
@@ -1,0 +1,14 @@
+#use-added-syntax(tests)
+defpackage slm/tests/test-tools:
+  import core
+
+#if-defined(TESTING) :
+  public defn expect-throw (f) -> Maybe<String>:
+    val res = try :
+      val unexpected = f()
+      None()
+    catch (e:Exception) :
+      val msg = to-string("%~" % [e])
+      One(msg)
+    #EXPECT(res is-not None)
+    res

--- a/tests/toml.stanza
+++ b/tests/toml.stanza
@@ -1,0 +1,82 @@
+#use-added-syntax(tests)
+defpackage slm/tests/toml:
+  import core
+  import collections
+
+  import semver
+
+  import slm/toml
+  import slm/dependency
+
+val exp-write = \<>name = "basic"
+version = "0.2.1"
+[dependencies]
+git-dep = "StanzaOrg/stanza-toml|1.2.3"
+path-dep = { path = "/home/john/src/sqlite" }
+<>
+
+
+deftest(toml) test-write-basic:
+
+  val uut = SlmToml(
+    "basic", "0.2.1", None(),
+    to-hashtable<String, Dependency>([
+      "git-dep" => GitDependency("git-dep", "StanzaOrg/stanza-toml", SemanticVersion(1, 2, 3), "")
+      "path-dep" => PathDependency("path-dep", "/home/john/src/sqlite")
+    ]))
+
+  val output = StringBuffer()
+
+  write(output, uut)
+
+  val obs-write = to-string(output)
+  #EXPECT( obs-write == exp-write)
+
+deftest(toml) test-find-dependency:
+  val uut = SlmToml(
+  "basic", "0.2.1", None(),
+  to-hashtable<String, Dependency>([
+    "git-dep" => GitDependency("git-dep", "StanzaOrg/stanza-toml", SemanticVersion(1, 2, 3), "")
+    "path-dep" => PathDependency("path-dep", "/home/john/src/sqlite")
+    "find-me" => GitDependency("find-me", "sqlite/sqlite", SemanticVersion(2, 0, 2), "")
+  ]))
+
+  val ret-pos = find-dependency(uut, "find-me")
+  #EXPECT(ret-pos is-not None)
+
+  val ret = value!(ret-pos)
+  #EXPECT(name(ret) == "find-me")
+
+  val ret-neg = find-dependency(uut, "not-present")
+  #EXPECT(ret-neg is None)
+
+deftest(toml) test-parse-slm-toml:
+  set-env("TEST_VAR", "/home/charles")
+  val uut = parse-slm-toml("./tests/data/test.toml")
+  unset-env("TEST_VAR")
+
+  #EXPECT(name(uut) == "test-slm")
+  #EXPECT(version(uut) == "0.2.1")
+  #EXPECT(compiler?(uut) == One("jstanza"))
+
+  val deps = dependencies(uut)
+  #EXPECT(length(to-tuple(deps)) ==  3)
+
+  val dep1 = deps["stanza-toml"]
+  match(dep1):
+    (git-dep:GitDependency):
+      #EXPECT(name(git-dep) == "stanza-toml")
+      #EXPECT(locator(git-dep) == "StanzaOrg/stanza-toml")
+      #EXPECT(version(git-dep) == SemanticVersion(1,2,3))
+
+  val dep2 = deps["sqlite"]
+  match(dep2):
+    (path-dep:PathDependency):
+      #EXPECT(name(path-dep) == "sqlite")
+      #EXPECT(path(path-dep) == "/home/john/src/sqlite")
+
+  val dep3 = deps["test-env"]
+  match(dep3):
+    (path-dep:PathDependency):
+      #EXPECT(name(path-dep) == "test-env")
+      #EXPECT(path(path-dep) == "/home/charles/asdf")

--- a/tests/utils.stanza
+++ b/tests/utils.stanza
@@ -1,0 +1,29 @@
+#use-added-syntax(tests)
+defpackage slm/tests/utils:
+  import core
+  import slm/utils
+
+deftest(utils) test-path-join:
+
+  #EXPECT(path-join("asdf", "qwer") == "asdf/qwer")
+  #EXPECT(path-join("/Users/john", "zxcv") == "/Users/john/zxcv")
+  #EXPECT(path-join("fdsa") == "fdsa")
+
+deftest(utils) test-split-any:
+
+  val testvecs = [
+    [["asdf", "^:~"], ["asdf"]],
+    [["asdf:qwer", "^:~"], ["asdf", "qwer"]],
+    [["asdf#qwer", "^:~"], ["asdf#qwer"]],
+    [["asdf~qwer", "^:~"], ["asdf", "qwer"]],
+    [["asdf^qwer~", "^:~"], ["asdf", "qwer~"]],
+    [["asdf:qwer:", "^:~"], ["asdf", "qwer:"]],
+  ]
+
+  for testvec in testvecs do:
+
+    val [inputvec, exp] = testvec
+    val [s, splitters] = inputvec
+
+    val obs = split-any(s, splitters)
+    #EXPECT(obs == exp)


### PR DESCRIPTION
This PR adds: 

1.  The `add` and `remove` commands for dependencies: 
     1.   You can run `slm add -git StanzaOrg/maybe-utils` and it will query Github, determine the latest version and then set that as the expected version in the `slm.toml` file.
     2.  You can also override:
          1.   The version with an explicit semantic version
          2.  The name
2.  This introduces a unit-test framework that we can expand on and improve.
    1.  I have tests for the `add` and `remove` functionality because I've written this code to be structured in a way that makes it more API friendly.
    2.  This has the added benefit of being more easy to test. 
    3.  We will need to work on refactoring other code to this model so that we can test and make an API from it. 
3.  I realized in doing this that the `add` function with the `-force` option is basically an `upgrade` operation. So that should make adding `upgrade` trivial.

I've also improved the handling so we should see error messages like:

```
➜  basic git:(main) ../../slm add -git Stanza0rg/DoesNotExist
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Failed to list tags from remote
```

When we fat finger or list the wrong repository. 

Closes JITX-6882