### PR TITLE
Add Path Version Specifier and some bugfixes from integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ To build a `slm` package, use `slm build`. This will create the `.slm` directory
 `slm` will define the `SLM_BUILD_VERSION` environment variable in the context of the `stanza build` process. This environment variable will be populated with the value of the `version` key from the `slm.toml` file for the project being built. This allows the project being built to incorporate this version number in any library or executable that it generates. See
 the `slm/commands/version` package for an example of how to use this in your project.
 
+## Repl
+
+You can use slm to handle dependency resolution before launching the repl as well:
+
+```
+$> slm repl src/main.stanza
+REPL environment is now inside package basic/main.
+stanza>
+```
+
 ## Publish
 
 To publish a `slm` package, use `slm publish`. For now, you must also have set an upstream (for example, by using `git branch -u <upstream-repo-url>`) for the branch you are on. You must also be in a clean state (no outstanding changes). `slm` will `git tag` the current version (as specified in your `slm.toml`) and then push it to your upstream.

--- a/src/commands/add.stanza
+++ b/src/commands/add.stanza
@@ -46,7 +46,7 @@ defn cli-add-dependency (cmd-args:CommandArgs) -> False :
   for kvp in paramTable do:
     debug("\t%_ = %_" % kvp)
 
-  val cfg = parse-slm-toml(cfg-path)
+  val cfg = parse-slm-toml(cfg-path, env-sub-enable = false)
 
   val cfg* = match(git-path, fs-path):
     (x:String, y:String):

--- a/src/commands/add.stanza
+++ b/src/commands/add.stanza
@@ -25,6 +25,7 @@ defn convert-version-spec (arg:String|False) -> Maybe<SemanticVersion> :
     (_): None()
 
 defn cli-add-dependency (cmd-args:CommandArgs) -> False :
+  val cfg-path = get?(cmd-args, "cfg", SLM_TOML_NAME)
   val git-path = get?(cmd-args, "git", false)
   val fs-path = get?(cmd-args, "path", false)
 
@@ -45,7 +46,7 @@ defn cli-add-dependency (cmd-args:CommandArgs) -> False :
   for kvp in paramTable do:
     debug("\t%_ = %_" % kvp)
 
-  val cfg = parse-slm-toml(SLM_TOML_NAME)
+  val cfg = parse-slm-toml(cfg-path)
 
   val cfg* = match(git-path, fs-path):
     (x:String, y:String):
@@ -63,7 +64,7 @@ defn cli-add-dependency (cmd-args:CommandArgs) -> False :
     val o = current-output-stream()
     write(o, cfg*)
   else:
-    within f = open(SLM_TOML_NAME, false):
+    within f = open(cfg-path, false):
       write(f, cfg*)
 
   debug("-- New File Write Complete --")
@@ -213,6 +214,12 @@ Add a new Path Dependency with name override
 
 <MSG>
 
+val CFG-FLAG = \<MSG>
+Select the configuration file to conduct the add operation on. The default
+value is the 'slm.toml' file in the current working directory.
+<MSG>
+
+
 val GIT-FLAG = \<MSG>
 Set the org/name path for a new 'GitDependency' to be added to the 'slm.toml' file
 of this project. By default, the basename is extracted as the dependency name. Use
@@ -254,6 +261,7 @@ project. It will output the resultant changes to std-out for inspection.
 
 public defn setup-add-cmd () -> Command :
   val addFlags = [
+    Flag("cfg", OneFlag, OptionalFlag, CFG-FLAG)
     Flag("git", OneFlag, OptionalFlag, GIT-FLAG)
     Flag("path", OneFlag, OptionalFlag, PATH-FLAG)
     Flag("name", OneFlag, OptionalFlag, NAME-FLAG)

--- a/src/commands/add.stanza
+++ b/src/commands/add.stanza
@@ -54,7 +54,7 @@ defn cli-add-dependency (cmd-args:CommandArgs) -> False :
     (x:String, y:False):
       add-git-dependency(cfg, x, version-spec?, name-override = name?, force = force )
     (x:False, y:String):
-      add-path-dependency(cfg, y, name-override = name?, force = force)
+      add-path-dependency(cfg, y, version-spec?, name-override = name?, force = force)
     (x:False, y:False):
       error("The 'add' command expects either a '-path' or '-git' argument. Neither were provided.")
 
@@ -140,7 +140,8 @@ public defn add-git-dependency (
 
 public defn add-path-dependency (
   cfg:SlmToml,
-  path:String
+  path:String,
+  version-spec?:Maybe<SemanticVersion>
   --
   name-override:Maybe<String> = None(),
   force:True|False = false
@@ -155,7 +156,7 @@ public defn add-path-dependency (
   val deps = to-hashtable<String, Dependency>( dependencies(cfg) )
   remove-dependency(existing, deps, force)
 
-  deps[name] = PathDependency(name, path)
+  deps[name] = PathDependency(name, path, version-spec?)
 
   sub-deps(cfg, deps)
 

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -50,12 +50,6 @@ defn write-slm-lock-file (dependencies: Tuple<Dependency>) -> False:
         (dep: PathDependency):
           println(f, "%_={}" % [name(dep)])
 
-defn get-build-args () -> Tuple<String>:
-  val ret = get-env("SLM_BUILD_ARGS")
-  match(ret):
-    (x:String): to-tuple $ split(x, " ")
-    (x:False): []
-
 defn get-build-target (cmd-args:CommandArgs) -> Tuple<String> :
   val arg = args(cmd-args)
   switch(length(arg)):
@@ -71,6 +65,7 @@ public defn build (cmd-args:CommandArgs) -> False:
   if verbose:
     slm/flags/debug? = true
 
+  val build-args = get?(cmd-args, "-", [])
   val targ? = get-build-target(cmd-args)
 
   ensure-slm-dir-structure-exists()
@@ -85,8 +80,6 @@ public defn build (cmd-args:CommandArgs) -> False:
   val cfg = parse-slm-toml(SLM_TOML_NAME)
   val stanza-exe = get-stanza-exe(compiler?(cfg))
   debug("with stanza='%_'" % [stanza-exe])
-
-  val build-args = get-build-args()
   debug("with build args '%,'" % [build-args])
 
   ; In general - we want all of the options for the project to be
@@ -111,11 +104,11 @@ The 'build' command will manage syncing dependencies and then
 building the project using the 'stanza build' process.
 
 The user can pass arguments to the 'stanza build' process
-by using the 'SLM_BUILD_ARGS' environment variable.
+by using the '-' flag argument.
 
 Example:
 
-$> SLM_BUILD_ARGS="-flag TESTING" slm build
+$> slm build -- -flags TESTING
 
 ---------------------------
 Package Version Propagation
@@ -158,8 +151,17 @@ val VERBOSE-FLAG = \<MSG>
 Generate verbose output from build.
 <MSG>
 
+val BUILD-ARGS-FLAG = \<MSG>
+To pass additional build arguments directly to the
+stanza build invokation, the user can use the '--'
+sequence. All arguments after the '--' will be
+passed directly to the build.
+<MSG>
+
 public defn setup-build-cmd () -> Command :
   val buildFlags = [
     Flag("verbose", ZeroFlag, OptionalFlag, VERBOSE-FLAG)
+    Flag("-", AllRemainingFlag, OptionalFlag, BUILD-ARGS-FLAG)
+
   ]
   Command("build", ZeroOrOneArg, BUILD-MSG-ARG, buildFlags, BUILD-MSG, build)

--- a/src/commands/remove.stanza
+++ b/src/commands/remove.stanza
@@ -12,9 +12,10 @@ defpackage slm/commands/remove:
 
 public defn cli-remove-dependency (cmd-args:CommandArgs) -> False :
   val targets = args(cmd-args)
+  val cfg-path = get?(cmd-args, "cfg", SLM_TOML_NAME)
   val dry-run? = get?(cmd-args, "dry-run", false)
 
-  val cfg = parse-slm-toml(SLM_TOML_NAME)
+  val cfg = parse-slm-toml(cfg-path)
 
   val cfg* = remove-dependency(cfg, targets)
 
@@ -24,7 +25,7 @@ public defn cli-remove-dependency (cmd-args:CommandArgs) -> False :
     val o = current-output-stream()
     write(o, cfg*)
   else:
-    within f = open(SLM_TOML_NAME, false):
+    within f = open(cfg-path, false):
       write(f, cfg*)
 
   debug("-- New File Write Complete --")
@@ -66,6 +67,11 @@ val RM-ARG-MSG = \<MSG>
 The remove command accepts one or more target dependency names for removal.
 <MSG>
 
+val CFG-FLAG = \<MSG>
+Select the configuration file to conduct the add operation on. The default
+value is the 'slm.toml' file in the current working directory.
+<MSG>
+
 val DRY-RUN-FLAG = \<MSG>
 This flag will cause 'slm' to do all of the checks and operations to perform
 an 'remove' operation - but it won't actually change the 'slm.toml' file of the
@@ -74,6 +80,7 @@ project. It will output the resultant changes to std-out for inspection.
 
 public defn setup-remove-cmd () -> Command :
   val rmFlags = [
+    Flag("cfg", OneFlag, OptionalFlag, CFG-FLAG)
     Flag("dry-run", ZeroFlag, OptionalFlag, DRY-RUN-FLAG)
   ]
 

--- a/src/commands/remove.stanza
+++ b/src/commands/remove.stanza
@@ -15,7 +15,7 @@ public defn cli-remove-dependency (cmd-args:CommandArgs) -> False :
   val cfg-path = get?(cmd-args, "cfg", SLM_TOML_NAME)
   val dry-run? = get?(cmd-args, "dry-run", false)
 
-  val cfg = parse-slm-toml(cfg-path)
+  val cfg = parse-slm-toml(cfg-path, env-sub-enable = false)
 
   val cfg* = remove-dependency(cfg, targets)
 

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -9,16 +9,11 @@ defpackage slm/commands/repl:
   import slm/toml
   import slm/utils
 
-defn get-repl-args () -> Tuple<String>:
-  val ret = get-env("SLM_REPL_ARGS")
-  match(ret):
-    (x:String): to-tuple $ split(x, " ")
-    (x:False): []
-
 public defn repl (cmd-args:CommandArgs) -> False:
   val cfg = parse-slm-toml(SLM_TOML_NAME)
   val stanza-exe = get-stanza-exe(compiler?(cfg))
-  val repl-args = get-repl-args()
+  val repl-args = get?(cmd-args, "-", [])
+
   val args = to-tuple $ cat-all([[stanza-exe, "repl"], repl-args])
   val slm-dir = path-join(get-cwd(), SLM_DIR)
 
@@ -39,12 +34,11 @@ val REPL-MSG = \<MSG>
 The 'repl' command will manage syncing dependencies and then
 run the project using the 'stanza repl' process.
 
-The user can pass arguments to the 'stanza repl' process
-by using the 'SLM_REPL_ARGS' environment variable.
+The user can pass arguments to the 'stanza repl' process.
 
 Example:
 
-$> SLM_REPL_ARGS="-flag TESTING" slm repl
+  $> slm repl -- file-to-run.stanza -flags TESTING
 
 ---------------------------
 Package Version Propagation
@@ -53,7 +47,7 @@ Package Version Propagation
 In order for the package's source code to know what its current
 version number is, this tool defines 'SLM_BUILD_VERSION' with the
 'version' string value from the 'slm.toml' file. This environment
-variable is defined for the context of the `stanza repl` process.
+variable is defined for the context of the 'stanza repl' process.
 
 This allows the package's stanza code to use '#env-var(SLM_BUILD_VERSION)'
 or 'get-env("SLM_BUILD_VERSION")' to access this version string and
@@ -61,5 +55,22 @@ compile it into the functions accessed by the repl.
 
 <MSG>
 
+val REPL-CMDLINE-ARGS = \<MSG>
+All command line arguments after the 'repl' command passed directly
+to the 'stanza repl' instance.
+<MSG>
+
+val REPL-ARGS-FLAG = \<MSG>
+To pass additional build arguments directly to the
+stanza repl invokation, the user can use the '--'
+sequence. All arguments after the '--' will be
+passed directly to the repl.
+<MSG>
+
+
 public defn setup-repl-cmd () -> Command :
-  Command("repl", ZeroArg, false, [], REPL-MSG, repl)
+  val replFlags = [
+    Flag("-", AllRemainingFlag, OptionalFlag, REPL-ARGS-FLAG)
+  ]
+
+  Command("repl", ZeroArg, false, replFlags, REPL-MSG, repl)

--- a/src/dependencies.stanza
+++ b/src/dependencies.stanza
@@ -70,6 +70,9 @@ defn parse-slm-lock-and-resolve-dependencies ():
                     delete 'slm clean', then re-run this command."
                     % [name(dep)])
             (path-dep:PathDependency):
+              val [is-compat, obs-version] = check-path-compatible(path-dep)
+              if not is-compat:
+                error-incompatible-path-version(path-dep, obs-version)
               path-dep
             (x:False):
               ; This dependency was found in the lock file but was not found
@@ -81,7 +84,7 @@ defn parse-slm-lock-and-resolve-dependencies ():
                     It is likely a grandchild dependency that is included as a path.\
                     We don't currently handle this case. Consider adding the\
                     necessary path dependency to the local project's 'slm.toml'\
-                    to work around this short-coming.")
+                    to work around this short-coming." % [name(dep)])
 
   for [name, dep] in pairs(slm-toml-dependencies) do:
     if get?(locked-dependencies, name) is False:
@@ -94,6 +97,32 @@ defn parse-slm-lock-and-resolve-dependencies ():
   ; any more inconsistencies that we don't yet detect (e.g. removing a dependency)
 
   to-tuple $ values $ locked-dependencies
+
+
+doc: \<DOC>
+Check if the version located at the desired path is compatible.
+
+Path Dependencies have an optional version that we can use to
+check the specified path. We're looking for compatibility
+with a particular version to head off issues where the API
+doesn't work.
+
+@return [Compatible?, Observed-Version]
+Compatable? - True if the versions are compatible or their is no
+expected version. False otherwise.
+Observed-Version - String indicating the version found in the
+<DOC>
+defn check-path-compatible (d:PathDependency) -> [True|False, String] :
+  val dep-path = path(d)
+  val cfg-path = path-join(dep-path, SLM_TOML_NAME)
+  val cfg = parse-slm-toml(cfg-path, env-sub-enable = false)
+  val obs-version-str = version(cfg)
+  val obs-version? = parse-semver(obs-version-str)
+  val is-compat = match(obs-version?, version?(d)):
+    (obs:One<SemanticVersion>, exp:One<SemanticVersion>):
+      compatible?(value!(obs), value!(exp))
+    (obs, exp:None): true
+  [is-compat, obs-version-str]
 
 defn fetch-or-sync-at-hash (d: GitDependency) -> False:
   if not has-git?() :
@@ -243,6 +272,13 @@ defn resolve-git-dependency? (
     val hash = git-rev-parse!(path(dep), "HEAD")
     One(dep $> sub-hash{_, hash})
 
+defn error-incompatible-path-version (dep:PathDependency, obs-version:String):
+  val msg = "The Path Dependency for '%_', found in '%_', has an incompatible version. \
+        The 'slm.toml' file expects version '%_'. The version found at that path is \
+        '%_'." % [name(dep), path(dep), version-string!(dep), obs-version]
+  error(msg, code = 240)
+
+
 defn resolve-path-dependency? (
   dep: PathDependency,
   resolved-dependencies: HashTable<String, Dependency>,
@@ -253,4 +289,9 @@ defn resolve-path-dependency? (
     ; resolved first.
     ; could occur is if
     fatal("internal inconsistency resolving path dependency '%_'" % [name(dep)])
+
+  val [is-compat, obs-version] = check-path-compatible(dep)
+  if not is-compat:
+    error-incompatible-path-version(dep, obs-version)
+
   One(dep)

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -19,9 +19,21 @@ public defmulti version-string? (d: Dependency) -> Maybe<String>:
 public defstruct PathDependency <: Dependency:
   name: String with: (as-method => true)
   path: String with: (as-method => true)
+  version?: Maybe<SemanticVersion> with: ( default => None() )
+
+defmethod version-string? (d:PathDependency) -> Maybe<String>:
+  match(version?(d)):
+    (x:None): x
+    (x:One<SemanticVersion>): One $ to-string(x)
+
+public defn version-string! (d:PathDependency) -> String:
+  to-string $ value-or(version?(d), "UNSPECIFIED")
 
 defmethod print (o:OutputStream, d:PathDependency) :
-  print(o, "%_ = { path = \"%_\" }" % [name(d), path(d)])
+  print(o, "%_ = { path = \"%_\"" % [name(d), path(d)])
+  match(version?(d)):
+    (x:None): print(o, " }")
+    (x:One<SemanticVersion>): print(o, ", version = \"%_\" }" % [to-string $ value(x)])
 
 ; Dependencies specified by Git locator/version (e.g. `foo = "myorg/myuser|1.0.0"`)
 public defstruct GitDependency <: Dependency:
@@ -110,9 +122,14 @@ defn env-var-substitute (path:String) -> String:
   within name = sub-curly(path):
     get-env!(name)
 
-public defn parse-path-dependency (name: String, path: String, env-sub-enable:True|False) -> PathDependency:
+public defn parse-path-dependency (name: String, path: String, version?:Maybe<String>, env-sub-enable:True|False) -> PathDependency:
   val path* = if env-sub-enable:
     env-var-substitute(path)
   else:
     path
-  PathDependency(name, path*)
+  val version = match(version?):
+    (x:None): x
+    (x:One<String>):
+      val sver = parse-semver(value(x)) $> expect{_, "SemanticVersion: couldn't parse  '%_'" % [x]}
+      One(sver)
+  PathDependency(name, path*, version)

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -110,6 +110,9 @@ defn env-var-substitute (path:String) -> String:
   within name = sub-curly(path):
     get-env!(name)
 
-public defn parse-path-dependency (name: String, path: String) -> PathDependency:
-  val path* = env-var-substitute(path)
+public defn parse-path-dependency (name: String, path: String, env-sub-enable:True|False) -> PathDependency:
+  val path* = if env-sub-enable:
+    env-var-substitute(path)
+  else:
+    path
   PathDependency(name, path*)

--- a/src/flags.stanza
+++ b/src/flags.stanza
@@ -12,3 +12,8 @@ public val SLM_DIR:String = ".slm"
 public val SLM_DEPS_DIR:String = path-join(SLM_DIR, "deps")
 public val SLM_PKGS_DIR:String = path-join(SLM_DIR, "pkgs")
 public val SLM_STANZA_PROJ:String = path-join(SLM_DIR, "stanza.proj")
+
+;;;;;;;;;;;;;;;;;;;;
+; Exit Codes
+
+public val SLM_INCOMPATIBLE_PATH_VERSION:Int = 240

--- a/src/logging.stanza
+++ b/src/logging.stanza
@@ -39,7 +39,7 @@ public defn info (msg: Printable|String) -> False:
   println(current-output-stream(), "%_ %_" % [program-prefix(), msg])
   flush(current-output-stream() as FileOutputStream)
 
-public defn error (msg: Printable|String) -> Void:
+public defn error (msg: Printable|String -- code:Int = 1) -> Void:
   val program = program-name()
   println(current-error-stream(), "%_ %_ %_" % [
     program-prefix(),
@@ -48,5 +48,5 @@ public defn error (msg: Printable|String) -> Void:
       $> clear-color?,
     msg,
   ])
-  exit(1)
+  exit(code)
 

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -120,6 +120,14 @@ variable and directly substitute that string if found. If no environment
 variable by that name is found, this is an error and will cause the `slm`
 build to fail.
 
+Path Resolution can also have an optional 'version' key that specifies a
+semantic version requirement for the referenced path dependency:
+
+dep-project = { path = "{HOME}/proj", version="1.2.0" }
+
+This will enforce a compatibility requirement for the referenced path
+dependency. The path dependency will need to be in the 'v1.x.y' series
+where x >= 2.
 <MSG>
 
 defn main ():

--- a/src/toml.stanza
+++ b/src/toml.stanza
@@ -18,7 +18,15 @@ public defstruct SlmToml:
   compiler?: Maybe<String>
   dependencies: HashTable<String, Dependency> with: (updater => sub-deps)
 
-public defn parse-slm-toml (path: String) -> SlmToml:
+doc: \<DOC>
+Parse the SLM TOML configuration file
+
+@param path Path to the file to parse.
+@param env-sub-enable Allow environment variable substitutions.
+This will replace strings like `{HOME}` with environment variable
+values if they exist.
+<DOC>
+public defn parse-slm-toml (path: String -- env-sub-enable:True|False = true) -> SlmToml:
   val table = path $> parse-file $> table
   val name = table["name"] as String
   val version = table["version"] as String
@@ -31,7 +39,7 @@ public defn parse-slm-toml (path: String) -> SlmToml:
         (specifier: String):
           parse-git-dependency(name, specifier)
         (table: TomlTable):
-          parse-path-dependency(name, table["path"] as String)
+          parse-path-dependency(name, table["path"] as String, env-sub-enable)
         (_):
           error("invalid slm.toml: '%_' is not a valid dependency specifier"
                 % [specifier])

--- a/src/toml.stanza
+++ b/src/toml.stanza
@@ -39,7 +39,10 @@ public defn parse-slm-toml (path: String -- env-sub-enable:True|False = true) ->
         (specifier: String):
           parse-git-dependency(name, specifier)
         (table: TomlTable):
-          parse-path-dependency(name, table["path"] as String, env-sub-enable)
+          val version? = match(get?(table, "version")):
+            (x:None): x
+            (x:One<TomlValue>): One(value(x) as String)
+          parse-path-dependency(name, table["path"] as String, version?, env-sub-enable)
         (_):
           error("invalid slm.toml: '%_' is not a valid dependency specifier"
                 % [specifier])

--- a/tests/commands/add.stanza
+++ b/tests/commands/add.stanza
@@ -121,7 +121,7 @@ deftest(add-cmd) test-add-path-basic:
     to-hashtable<String, Dependency>([])
   )
 
-  val uut = add-path-dependency(input, "/Users/ted/src/stanza-toml")
+  val uut = add-path-dependency(input, "/Users/ted/src/stanza-toml", None())
 
   #EXPECT( name(uut) == "my-pkg" )
   #EXPECT( version(uut) == "0.1.2" )
@@ -135,6 +135,7 @@ deftest(add-cmd) test-add-path-basic:
   val dep = deps["stanza-toml"] as PathDependency
   #EXPECT(name(dep) == "stanza-toml")
   #EXPECT(path(dep) == "/Users/ted/src/stanza-toml")
+  #EXPECT(version?(dep) == None())
 
 deftest(add-cmd) test-add-path-name-override:
 
@@ -148,7 +149,7 @@ deftest(add-cmd) test-add-path-name-override:
     ])
   )
 
-  val uut = add-path-dependency(input, "/Users/ted/src/stanza-toml", name-override = One("toml-extreme"))
+  val uut = add-path-dependency(input, "/Users/ted/src/stanza-toml", None(), name-override = One("toml-extreme"))
 
   #EXPECT( name(uut) == "my-pkg" )
   #EXPECT( version(uut) == "0.1.2" )
@@ -161,6 +162,45 @@ deftest(add-cmd) test-add-path-name-override:
   val dep = deps["toml-extreme"] as PathDependency
   #EXPECT(name(dep) == "toml-extreme")
   #EXPECT(path(dep) == "/Users/ted/src/stanza-toml")
+  #EXPECT(version?(dep) == None())
+
+  var gdep = deps["maybe-utils"] as GitDependency
+  #EXPECT(name(gdep) == "maybe-utils")
+  #EXPECT(locator(gdep) == "StanzaOrg/maybe-utils")
+  #EXPECT(version(gdep) == SemanticVersion(0,1,4))
+
+  gdep = deps["semver"] as GitDependency
+  #EXPECT(name(gdep) == "semver")
+  #EXPECT(locator(gdep) == "StanzaOrg/semver")
+  #EXPECT(version(gdep) == SemanticVersion(0,1,2))
+
+
+deftest(add-cmd) test-add-path-with-version:
+
+  val input = SlmToml(
+    "my-pkg",
+    "0.1.2",
+    None(),
+    to-hashtable<String, Dependency>([
+      "maybe-utils" => GitDependency("maybe-utils", "StanzaOrg/maybe-utils", SemanticVersion(0,1,4), "")
+      "semver" => GitDependency("semver", "StanzaOrg/semver", SemanticVersion(0,1,2), "")
+    ])
+  )
+
+  val uut = add-path-dependency(input, "/Users/ted/src/stanza-toml", One $ SemanticVersion(1, 0, 3))
+
+  #EXPECT( name(uut) == "my-pkg" )
+  #EXPECT( version(uut) == "0.1.2" )
+  #EXPECT( compiler?(uut) == None() )
+
+  val deps = dependencies(uut)
+  val names = to-tuple $ keys(deps)
+  #EXPECT( length(names) == 3 )
+
+  val dep = deps["stanza-toml"] as PathDependency
+  #EXPECT(name(dep) == "stanza-toml")
+  #EXPECT(path(dep) == "/Users/ted/src/stanza-toml")
+  #EXPECT(version?(dep) == One $ SemanticVersion(1, 0, 3))
 
   var gdep = deps["maybe-utils"] as GitDependency
   #EXPECT(name(gdep) == "maybe-utils")


### PR DESCRIPTION
Closes JITX-7201

1.  This refactors the `repl` and `build` commands to make it easier to pass arguments instead of using an EnvVar. I didn't realize there was a flag for `capture all remaining args` when I did the initial refactor. This setup is easier to integrate cleanly into JITX
2.  Changed the `slm.toml` parsing to not use env-var substitution during the `add` and `remove` commands. This was causing problems where the `{JITX_ROOT}` references were converted to literal paths on subsequent adds.
3.  Adds a new `-cfg` option for `add` and `remove` to avoid unnecessary `change directory`.
4.  Adds a version optional parameter for `PathDependency` so that we can spec a specific path dependency as needed.