### PR TITLE
Fix windows path issues, repl dep sync, and integrate tests into ci

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -51,10 +51,15 @@ def fetch_package_into(path, package, version):
         error(f"failed fetching package {package}")
 
 def generate_stanza_proj():
-    dep_proj_files = [
-        f"{SLM_DEPS_DIR}/{dep}/stanza.proj"
-        for dep in DEPENDENCIES.keys()
-    ]
+    dep_proj_files = []
+    for dep in DEPENDENCIES.keys():
+      dep_path = os.path.join(SLM_DEPS_DIR, dep, "stanza.proj")
+      # For Windows - we replace the `\` with `/` so that the
+      #  'stanza build' invokation will actually run. Otherwise,
+      #   stanza treats the `\` as an escape sequence and fails to build.
+      #   On Mac/Linux - this should do nothing.
+      dep_unnorm = dep_path.replace(os.sep, '/')
+      dep_proj_files.append(dep_unnorm)
 
     with open(os.path.join(SLM_DIR, "stanza.proj"), "w") as f:
         f.writelines([f'include "{proj_file}"\n' for proj_file in dep_proj_files])

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -6,3 +6,8 @@ set -eu
 
 ./slm clean
 ./slm build
+
+# Build the tests
+
+./slm build tests
+./slm-tests

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -34,10 +34,12 @@ public defn ensure-slm-dir-structure-exists () -> False:
 
 defn write-build-stanza-proj (dependencies: Tuple<Dependency>) -> False:
   within f = open(SLM_STANZA_PROJ, false):
-    val deps-dir = path-join(get-cwd(), SLM_DEPS_DIR)
     for dep in dependencies do:
-      val dep-path = get-cwd() $> parse-path $> relative-to-dir{_, dep $> /path}
-      val dep-stanza-proj = path-join(to-string(dep-path), "stanza.proj")
+      val dep-path = path-join(path(dep), "stanza.proj")
+      val stanza-proj? = resolve-path(dep-path)
+      val dep-stanza-proj = un-norm-path $ match(stanza-proj?):
+        (x:False): throw $ Exception("Failed to Resolve Path %_. Make double check path dependencies and confirm expected git repos in '.slm/deps'" % [dep-path])
+        (x:String): x
       println(f, to-string(\<>include "%_"<> % [dep-stanza-proj]))
 
 defn write-slm-lock-file (dependencies: Tuple<Dependency>) -> False:

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -21,37 +21,6 @@ defpackage slm/commands/build:
   import slm/toml
   import slm/utils
 
-public defn ensure-slm-dir-structure-exists () -> False:
-  defn create-dir! (path: String) -> True|False:
-    if not file-exists?(path):
-      create-dir(path)
-      true
-
-  if create-dir!(SLM_DIR):
-    for build-dir in [SLM_DEPS_DIR, SLM_PKGS_DIR] do:
-      create-dir!(build-dir)
-  false
-
-defn write-build-stanza-proj (dependencies: Tuple<Dependency>) -> False:
-  within f = open(SLM_STANZA_PROJ, false):
-    for dep in dependencies do:
-      val dep-path = path-join(path(dep), "stanza.proj")
-      val stanza-proj? = resolve-path(dep-path)
-      val dep-stanza-proj = un-norm-path $ match(stanza-proj?):
-        (x:False): throw $ Exception("Failed to Resolve Path %_. Make double check path dependencies and confirm expected git repos in '.slm/deps'" % [dep-path])
-        (x:String): x
-      println(f, to-string(\<>include "%_"<> % [dep-stanza-proj]))
-
-defn write-slm-lock-file (dependencies: Tuple<Dependency>) -> False:
-  within f = open(SLM_LOCK_NAME, false):
-    for dep in dependencies do:
-      match(dep):
-        (dep: GitDependency):
-          println(f, "%_={locator=%~,version=%~,hash=%~}"
-                  % [name(dep), locator(dep), to-string(version(dep)), hash(dep)])
-        (dep: PathDependency):
-          println(f, "%_={}" % [name(dep)])
-
 defn get-build-target (cmd-args:CommandArgs) -> Tuple<String> :
   val arg = args(cmd-args)
   switch(length(arg)):
@@ -70,12 +39,7 @@ public defn build (cmd-args:CommandArgs) -> False:
   val build-args = get?(cmd-args, "-", [])
   val targ? = get-build-target(cmd-args)
 
-  ensure-slm-dir-structure-exists()
-
   val dependencies = slm/dependencies/fetch-and-sync()
-
-  write-build-stanza-proj(dependencies)
-  write-slm-lock-file(dependencies)
 
   val slm-dir = path-join(get-cwd(), SLM_DIR)
 

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -2,6 +2,7 @@ defpackage slm/commands/repl:
   import core
   import arg-parser
 
+  import slm/dependencies
   import slm/flags
   import slm/file-utils
   import slm/process-utils
@@ -13,6 +14,8 @@ public defn repl (cmd-args:CommandArgs) -> False:
   val cfg = parse-slm-toml(SLM_TOML_NAME)
   val stanza-exe = get-stanza-exe(compiler?(cfg))
   val repl-args = get?(cmd-args, "-", [])
+
+  val dependencies = slm/dependencies/fetch-and-sync()
 
   val args = to-tuple $ cat-all([[stanza-exe, "repl"], repl-args])
   val slm-dir = path-join(get-cwd(), SLM_DIR)

--- a/src/dependencies.stanza
+++ b/src/dependencies.stanza
@@ -11,6 +11,7 @@ defpackage slm/dependencies:
 
   import slm/flags
   import slm/dependency
+  import slm/file-utils
   import slm/git-utils
   import slm/lock
   import slm/logging
@@ -18,15 +19,56 @@ defpackage slm/dependencies:
   import slm/utils
 
 public defn fetch-and-sync () -> Tuple<Dependency>:
+
+  ensure-slm-dir-structure-exists()
+
   ; There are two main strategies we'll use
   ; 1. If there's a slm.lock, then we resolve all dependencies to that exact hash
   ;    using only the lockfile.
   ;
   ; 2. Otherwise we use the slm.toml
-  if file-exists?(SLM_LOCK_NAME):
+  val deps = if file-exists?(SLM_LOCK_NAME):
     parse-slm-lock-and-resolve-dependencies()
   else:
     parse-slm-toml-and-resolve-dependencies()
+
+  write-build-stanza-proj(deps)
+  write-slm-lock-file(deps)
+
+  deps
+
+
+defn ensure-slm-dir-structure-exists () -> False:
+  defn create-dir! (path: String) -> True|False:
+    if not file-exists?(path):
+      create-dir(path)
+      true
+
+  if create-dir!(SLM_DIR):
+    for build-dir in [SLM_DEPS_DIR, SLM_PKGS_DIR] do:
+      create-dir!(build-dir)
+  false
+
+defn write-build-stanza-proj (dependencies: Tuple<Dependency>) -> False:
+  within f = open(SLM_STANZA_PROJ, false):
+    for dep in dependencies do:
+      val dep-path = path-join(path(dep), "stanza.proj")
+      val stanza-proj? = resolve-path(dep-path)
+      val dep-stanza-proj = un-norm-path $ match(stanza-proj?):
+        (x:False): throw $ Exception("Failed to Resolve Path %_. Make double check path dependencies and confirm expected git repos in '.slm/deps'" % [dep-path])
+        (x:String): x
+      println(f, to-string(\<>include "%_"<> % [dep-stanza-proj]))
+
+defn write-slm-lock-file (dependencies: Tuple<Dependency>) -> False:
+  within f = open(SLM_LOCK_NAME, false):
+    for dep in dependencies do:
+      match(dep):
+        (dep: GitDependency):
+          println(f, "%_={locator=%~,version=%~,hash=%~}"
+                  % [name(dep), locator(dep), to-string(version(dep)), hash(dep)])
+        (dep: PathDependency):
+          println(f, "%_={}" % [name(dep)])
+
 
 defn parse-slm-lock-and-resolve-dependencies ():
   val slm-toml-dependencies = parse-slm-toml(SLM_TOML_NAME) $> dependencies

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -7,6 +7,7 @@ defpackage slm/dependency:
 
   import slm/logging
   import slm/utils
+  import slm/file-utils
   import slm/flags
 
 public deftype Dependency
@@ -122,11 +123,14 @@ defn env-var-substitute (path:String) -> String:
   within name = sub-curly(path):
     get-env!(name)
 
+
+
 public defn parse-path-dependency (name: String, path: String, version?:Maybe<String>, env-sub-enable:True|False) -> PathDependency:
-  val path* = if env-sub-enable:
+  val path* = un-norm-path $ if env-sub-enable:
     env-var-substitute(path)
   else:
     path
+
   val version = match(version?):
     (x:None): x
     (x:One<String>):

--- a/src/file-utils.stanza
+++ b/src/file-utils.stanza
@@ -12,15 +12,34 @@ public defn open (f: (FileOutputStream) -> False, path: String, append?: True|Fa
   try: f(file)
   finally: close(file)
 
+
+doc: \<DOC>
+Convert Windows Backlash Path to Forward Slash Variant
+
+This is the reverse of the `norm-path` function in lbstanza core.
+This function is intended to help convert windows backslash paths
+into a consistent format (ie, linux/mac OS-X path format).
+<DOC>
+public defn un-norm-path (path:String) -> String :
+  #if-defined(PLATFORM-WINDOWS):
+    defn convert-backslash-to-forward (path:String) -> String :
+      replace(path, "\\", "/")
+    convert-backslash-to-forward(path)
+  #else:
+    path
+
 lostanza val GET-CWD-BUFF-SIZE: long = 0x1000L
 extern getcwd: (ptr<byte>, long) -> ptr<byte>
 
-public lostanza defn get-cwd () -> ref<String>:
+lostanza defn int-get-cwd () -> ref<String>:
   val buff = call-c clib/malloc(GET-CWD-BUFF-SIZE)
   call-c getcwd(buff, GET-CWD-BUFF-SIZE)
   val ret = String(buff)
   call-c clib/free(buff)
   return ret
+
+public defn get-cwd () -> String :
+  un-norm-path $ int-get-cwd()
 
 public defn dir-name? (path: String) -> Maybe<String>:
   split-last(path, '/') $> map{_, first}

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -128,6 +128,16 @@ dep-project = { path = "{HOME}/proj", version="1.2.0" }
 This will enforce a compatibility requirement for the referenced path
 dependency. The path dependency will need to be in the 'v1.x.y' series
 where x >= 2.
+
+Note about Windows:
+
+Paths on Windows can be represented with backslash '\' separators or
+with forward slash '/' separators. All paths will be converted to forward
+slash '/' when written to files. The '\' presents some issues when used
+in 'stanza.proj' files. In 'stanza.proj' files the '\' character must be
+escaped (ie, '\\' ) otherwise, stanza will fail to parse the path correctly.
+Using forward slash avoids this problem.
+
 <MSG>
 
 defn main ():


### PR DESCRIPTION
This fixes some bugs in encountered when testing on Windows related to the path with `\` characters.
Additionally, I've updated the `repl` to sync dependencies (previously only the build was doing so)
Finally, I've added the tests to the CI. Let's hope they pass 😄 