### PR TITLE
Refactor Git Dependencies to use standardize format

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -2,7 +2,7 @@ name = "slm"
 version = "0.3.2"
 
 [dependencies]
-stanza-toml = "StanzaOrg/stanza-toml|0.3.4"
-semver      = "StanzaOrg/semver|0.1.6"
-maybe-utils = "StanzaOrg/maybe-utils|0.1.4"
-term-colors = "StanzaOrg/term-colors|0.1.1"
+stanza-toml = { git = "StanzaOrg/stanza-toml", version = "0.3.4" }
+semver      = { git = "StanzaOrg/semver", version = "0.1.6" }
+maybe-utils = { git = "StanzaOrg/maybe-utils", version = "0.1.4" }
+term-colors = { git = "StanzaOrg/term-colors", version = "0.1.1" }

--- a/src/commands/add.stanza
+++ b/src/commands/add.stanza
@@ -177,7 +177,7 @@ Add a new Github dependency at the latest tag:
 
   """
   [dependencies]
-  stanza-toml = "StanzaOrg/stanza-toml|0.3.5"
+  stanza-toml = { git = "StanzaOrg/stanza-toml", version = "0.3.5" }
   """
 
 Add a new Github dependency at a particular version
@@ -188,7 +188,7 @@ Add a new Github dependency at a particular version
 
   """
   [dependencies]
-  stanza-toml = "StanzaOrg/stanza-toml|0.3.4"
+  stanza-toml = { git = "StanzaOrg/stanza-toml", version = "0.3.4" }
   """
 
 Add a new Path Dependency

--- a/src/dependency.stanza
+++ b/src/dependency.stanza
@@ -49,7 +49,7 @@ defmethod version-string? (d: GitDependency) -> One<String>:
   One(version-string(d))
 
 defmethod print (o:OutputStream, d:GitDependency) :
-  print(o, "%_ = \"%_|%_\"" % [name(d), locator(d), version-string(d)])
+  print(o, "%_ = { git = \"%_\" version = \"%_\" }" % [name(d), locator(d), version-string(d)])
 
 public defn version-string (d: GitDependency) -> String:
   to-string(version(d))
@@ -64,7 +64,15 @@ public defn colored-name? (d: Dependency) -> ColoredString:
     $> bold $> foreground{_, TerminalBrightWhite}
     $> clear-color?
 
+
+doc: \<DOC>
+Legacy Version of the Git Dependency Parser
+
+The legacy version uses a string in the form `name|0.1.2`
+where `0.1.2` is the version for the dependency.
+<DOC>
 public defn parse-git-dependency (name: String, specifier: String):
+  info("Extracting Legacy Github Dependency Specifier for '%_'. Consider Upgrading to Toml Table Variable" % [name])
   GitDependency(name, locator, requested-version, hash)
 where:
   val [locator, requested-version] = parse-specifier(specifier)
@@ -82,6 +90,16 @@ defn parse-specifier (specifier: String) -> [String, SemanticVersion]:
     else:
       error("malformed specifier '%_'" % [specifier])
 
+public defn parse-git-dependency (name:String, locator:String, version?:Maybe<String>) -> GitDependency :
+  val version = match(version?):
+    (x:None):
+      throw $ Exception("Invalid Git Dependency[%_]: No Version Attribute found"% [name])
+    (x:One<String>):
+      parse-semver(value(x)) $>
+        expect{_, "Git Dep[%_]: Failed to Parse Version: '%_'" % [name, x]}
+
+  val hash = "" ; This gets resolved during the fetch/sync
+  GitDependency(name, locator, version, hash)
 
 ; This function was shamelessly stolen from lbstanza:compiler/config.stanza
 ; https://github.com/StanzaOrg/lbstanza/blob/0cbcd2ce7d8b1794e82624170a0a09d3053d0fb1/compiler/config.stanza#L298

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -77,11 +77,16 @@ name = "slm"
 version = "0.3.2"
 
 [dependencies]
-stanza-toml = "StanzaOrg/stanza-toml|0.3.4"
-semver      = "StanzaOrg/semver|0.1.4"
-maybe-utils = "StanzaOrg/maybe-utils|0.1.4"
-term-colors = "StanzaOrg/term-colors|0.1.1"
+stanza-toml.git = "StanzaOrg/stanza-toml"
+stanza-toml.version = "0.3.4"
+maybe-utils.git = "StanzaOrg/maybe-utils"
+maybe-utils.version = "0.1.4"
+semver      = { git = "StanzaOrg/semver", version = "0.1.4" }
+term-colors = { git = "StanzaOrg/term-colors", version = "0.1.1" }
 """
+
+Notice the identical means of expressing a TOML table using either dot-separated
+syntax or the more JSON-like syntax.
 
 Dependency Declarations:
 
@@ -93,13 +98,15 @@ forms:
 
 The github resolution is a String formatted as:
 
-dep-project = "ORG/PROJECT|SEMVER"
+dep-project = { git = "ORG/PROJECT", version = "SEMVER" }
 
  - dep-project = Name of the dependency we are resolving.
- - ORG = The Github Organization where the project can be found.
- - PROJECT = Name of the project under the github org.
- - SEMVER = Semantic version for the project. This semantic version
-    must match a tag on the 'https://github.com/ORG/PROJECT' repository.
+ - git - Required path to repository on Github
+   - ORG = The Github Organization where the project can be found.
+   - PROJECT = Name of the project under the github org.
+ - version - Required version for the dependency.
+   - SEMVER = Semantic version for the project. This semantic version
+     must match a tag on the 'https://github.com/ORG/PROJECT' repository.
 
 2.  File Path Resolution
 

--- a/src/toml.stanza
+++ b/src/toml.stanza
@@ -30,24 +30,36 @@ public defn parse-slm-toml (path: String -- env-sub-enable:True|False = true) ->
   val table = path $> parse-file $> table
   val name = table["name"] as String
   val version = table["version"] as String
-  val compiler? = match(get?(table, "compiler")):
-    (x:None): x
-    (x:One<TomlValue>):  One(value(x) as String)
+  val compiler? = extract-as-str? $ get?(table, "compiler")
   val dependencies = to-hashtable<String, Dependency> $
     for [name, specifier] in pairs(table["dependencies"] as TomlTable) seq:
       name => match(specifier):
-        (specifier: String):
-          parse-git-dependency(name, specifier)
-        (table: TomlTable):
-          val version? = match(get?(table, "version")):
-            (x:None): x
-            (x:One<TomlValue>): One(value(x) as String)
-          parse-path-dependency(name, table["path"] as String, version?, env-sub-enable)
-        (_):
-          error("invalid slm.toml: '%_' is not a valid dependency specifier"
-                % [specifier])
+        (legacy:String):
+          parse-git-dependency(name, legacy)
+        (table:TomlTable):
+          parse-dependency(name, table, env-sub-enable)
 
   SlmToml(name, version, compiler?, dependencies)
+
+defn extract-as-str? (v:Maybe<TomlValue>) -> Maybe<String> :
+  match(v):
+    (x:None): x
+    (x:One<TomlValue>): One $ (value(x) as String)
+
+defn parse-dependency (name:String, table:TomlTable, env-sub-enable:True|False) -> Dependency :
+  val pathAttr = extract-as-str? $ get?(table, "path")
+  val gitAttr = extract-as-str? $ get?(table, "git")
+  val version = extract-as-str? $ get?(table, "version")
+  match(pathAttr, gitAttr):
+    (p:One<String>, g:One<String>):
+      throw $ Exception("Invalid Dependency[%_]: The 'path' and 'git' attributes are mutually exclusive" % [name])
+    (p:One<String>, g:None): ; Path Dependency
+      parse-path-dependency(name, value(p), version, env-sub-enable)
+    (p:None, g:One<String>): ; Git Dependency
+      parse-git-dependency(name, value(g), version)
+    (p:None, g:None):
+      throw $ Exception("Invalid Dependency[%_]: Expected either a 'path' or 'git' attribute but found neither" % [name])
+
 
 doc: \<DOC>
 Output the SlmToml config as a valid TOML file.

--- a/tests/data/error_git_path_mutex.toml
+++ b/tests/data/error_git_path_mutex.toml
@@ -3,5 +3,5 @@ version = "0.2.1"
 compiler = "jstanza"
 [dependencies]
 stanza-toml = { git = "StanzaOrg/stanza-toml", version = "1.2.3" }
-sqlite = { path = "/home/john/src/sqlite" }
+sqlite = { path = "/home/john/src/sqlite", git = "This/IsAnError" }
 test-env = { path = "{TEST_VAR}/asdf" }

--- a/tests/data/error_no_git_or_path.toml
+++ b/tests/data/error_no_git_or_path.toml
@@ -2,6 +2,6 @@ name = "test-slm"
 version = "0.2.1"
 compiler = "jstanza"
 [dependencies]
-stanza-toml = { git = "StanzaOrg/stanza-toml", version = "1.2.3" }
-sqlite = { path = "/home/john/src/sqlite" }
+stanza-toml = { version = "1.2.3" }
+sqlite = { path = "/home/john/src/sqlite", git = "This/IsAnError" }
 test-env = { path = "{TEST_VAR}/asdf" }

--- a/tests/toml.stanza
+++ b/tests/toml.stanza
@@ -8,10 +8,12 @@ defpackage slm/tests/toml:
   import slm/toml
   import slm/dependency
 
+  import slm/tests/test-tools
+
 val exp-write = \<>name = "basic"
 version = "0.2.1"
 [dependencies]
-git-dep = "StanzaOrg/stanza-toml|1.2.3"
+git-dep = { git = "StanzaOrg/stanza-toml" version = "1.2.3" }
 path-dep = { path = "/home/john/src/sqlite" }
 <>
 
@@ -80,3 +82,31 @@ deftest(toml) test-parse-slm-toml:
     (path-dep:PathDependency):
       #EXPECT(name(path-dep) == "test-env")
       #EXPECT(path(path-dep) == "/home/charles/asdf")
+
+deftest(toml) test-parse-mutex-error:
+  set-env("TEST_VAR", "/home/charles")
+
+  defn fail-on-mutex-git-path () :
+    parse-slm-toml("./tests/data/error_git_path_mutex.toml")
+
+  val msg = expect-throw(fail-on-mutex-git-path)
+
+  unset-env("TEST_VAR")
+
+  #EXPECT(msg is-not None)
+  #EXPECT(index-of-chars(value!(msg), "'path' and 'git' attributes are mutually exclusive") is-not False)
+
+
+deftest(toml) test-parse-malformed-error:
+  set-env("TEST_VAR", "/home/charles")
+
+  defn fail-on-no-git-path () :
+    parse-slm-toml("./tests/data/error_no_git_or_path.toml")
+
+  val msg = expect-throw(fail-on-no-git-path)
+
+  unset-env("TEST_VAR")
+
+  #EXPECT(msg is-not None)
+  #EXPECT(index-of-chars(value!(msg), "Expected either a 'path' or 'git' attribute") is-not False)
+


### PR DESCRIPTION
This refactors the git dependency specification from a custom string: 

`maybe-utils = "StanzaOrg/maybe-utils|0.1.5"`

To a standard TOML format like the `PathDependency`:

```
maybe-utils.git = "StanzaOrg/maybe-utils"
maybe-utils.version = "0.1.5"
```

I've left the legacy implementation in place to make upgrading easier. We can remove that as we get everything updated.