### PR TITLE
Fix Conan Build - Consistent Repo Hash IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ To build the Conan2 package for binary distribution of `slm`:
         2.  Confirm: `conan profile show -pr default`
             1.  This will show the default configuration.
 3.  Run the conan build:
-    1.  `conan create . -s os="Macos" -s arch="x86_64"`
-    2.  You can replace os with `Windows` or `Linux`
-    3.  No Promises on `Windows` build working yet.
+    1.  Mac/Linux: `build_conan.sh`
+    2.  Windows: `build_conan.ps1`
 4.  Publish the package:
     1.  `conan remote add <NAME> <URL>`
         1.  You should only have to do this once.

--- a/build_conan.ps1
+++ b/build_conan.ps1
@@ -1,0 +1,2 @@
+$env:SLM_ROOT_DIR = Get-Location
+conan create .

--- a/build_conan.sh
+++ b/build_conan.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# Script to run the conan build and generate the required packages
+#
+# Current usage of Conan is kind of a hack. We're not having conan
+#  to run the `stanza build`. This means I have to get the binary
+#  to the package some how and Conan makes this more difficult than
+#  just copying it to a file. I don't get access to the `recipe_folder`
+#  after the `export_sources` function. But I can't copy the binary in
+#  `export_sources_folder` because anything in that directory gets hashed
+#  as part of the repository id.
+#
+# I must pass this directory as an environment variable
+#  so that each run of `conanfile.py` gets the same directory.
+export SLM_ROOT_DIR=$(pwd)
+conan create .

--- a/conanfile.py
+++ b/conanfile.py
@@ -12,6 +12,8 @@ from conan import ConanFile
 from conan.tools.files import copy
 import tomllib
 
+SLM_FOLDER = None
+
 def get_slm_config(fp = "./slm.toml"):
     with open(fp, "rb") as f:
       data = tomllib.load(f)
@@ -73,11 +75,16 @@ class slmRecipe(ConanFile):
         if len(success) != len(self.dist_files()):
           raise RuntimeError("Export: Failed to Copy Distribution Files")
 
-    def export_sources(self):
-        self.copy_dist_files(self.recipe_folder, self.export_sources_folder)
+    # def export_sources(self):
+    #     # Anything copied to the export sources folder will
+    #     #  get hashed to create the repository id. We want this
+    #     #  to be consistent from OS to OS.
+    #  TODO - When we get the `stanza build` running through conan
+    #    We would copy sources here and then run the build.
 
     def build(self):
-        self.copy_dist_files(self.export_sources_folder, self.build_folder)
+        SLM_FOLDER = os.environ["SLM_ROOT_DIR"]
+        self.copy_dist_files(SLM_FOLDER, self.build_folder)
 
     def package(self):
         # Slight deviation here - I want the binary in the `bin`

--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "slm"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 stanza-toml = { git = "StanzaOrg/stanza-toml", version = "0.3.4" }


### PR DESCRIPTION
This refactors the `conanfile.py` to get a consistent hash id on different platforms.

Note also - that `git config core.autocrlf false` might also be necessary on windows so that the `conanfile.py` does not have `CRLF` line endings. 

I've added a script to help run the build on both linux/mac/windows.
I've confirmed that I get the same hash on mac and windows. I'll be checking linux shortly. 