### PR TITLE
Tweak EnvVars for Differentiating Shared vs Static

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "slm"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 stanza-toml = { git = "StanzaOrg/stanza-toml", version = "0.4.0" }

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -47,6 +47,12 @@ public defn build (cmd-args:CommandArgs) -> False:
   ;  in static library mode to be able to compile in the build command.
   set-env("SLM_BUILD_STATIC", "1")
 
+  ; Binary Variable that is used in both build/repl for scripts
+  ;   that want to differentiate that way.
+  ;   This is primarily added for 'conan' because it wants:
+  ;   '--shared=(True|False)'
+  set-env("SLM_BUILD_DYNAMIC_LIB", "False")
+
   val platform = get-platform()
   set-env("SLM_PLATFORM", platform)
 
@@ -106,9 +112,13 @@ Static Dependency Construction
 With the task dependencies, external programs can be used to build
 the artifacts needed to load functionality from a static C library.
 To support this, the 'build' command defines the environment
-variable 'SLM_BUILD_STATIC'. This environment variable is intended
+variable 'SLM_BUILD_STATIC=True'. This environment variable is intended
 to indicate to any of the task dependencies that a static library
 is needed (as opposed to a shared library, like a *.dll)
+
+Additionally, the 'build' command defines the environment variable
+'SLM_BUILD_DYNAMIC_LIB=False'. This is the same env-var used by the 'repl'
+command which makes it easier for scripts to just reference one variable.
 
 The 'slm' binary will also define the 'SLM_PLATFORM' environment
 variable during the dependendency resolution process. This environment

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -24,6 +24,10 @@ public defn repl (cmd-args:CommandArgs) -> False:
   ;  in shared library mode to be able to load in the repl.
   set-env("SLM_BUILD_SHARED", "1")
 
+  ; Binary Variable that is used in both build/repl for scripts
+  ;   that want to differentiate that way.
+  set-env("SLM_BUILD_DYNAMIC_LIB", "True")
+
   val platform = get-platform()
   set-env("SLM_PLATFORM", platform)
 
@@ -75,9 +79,13 @@ Shared Dependency Construction
 With the task dependencies, external programs can be used to build
 the artifacts needed to load functionality from a shared C library.
 To support this, the 'repl' command defines the environment
-variable 'SLM_BUILD_SHARED'. This environment variable is intended
+variable 'SLM_BUILD_SHARED=1'. This environment variable is intended
 to indicate to any of the task dependencies that a shared library
 (like a *.so, *.dylib, *.dll) is needed (as opposed to a static library)
+
+Additionally, the 'repl' command defines the environment variable
+'SLM_BUILD_DYNAMIC_LIB=True'. This is the same env-var used by the 'build'
+command which makes it easier for scripts to just reference one variable.
 
 The 'slm' binary will also define the 'SLM_PLATFORM' environment
 variable during the dependendency resolution process. This environment


### PR DESCRIPTION
This adds a new env-var that should make it easier to use `conan`.

We should be able to do:

```
conan install --shared={SLM_BUILD_DYNAMIC_LIB} ...
```
