### PR TITLE
Add the `run` command

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "slm"
-version = "0.6.0"
+version = "0.6.1"
 
 # keep these dependencies in sync with the list in bootstrap.py
 # note that the slm bootstrap.py script doesn't recursively resolve dependencies

--- a/src/commands.stanza
+++ b/src/commands.stanza
@@ -15,6 +15,7 @@ defpackage slm/commands:
     only => (setup-remove-cmd)
   forward slm/commands/repl with:
     only => (setup-repl-cmd)
+  forward slm/commands/run with:
+    only => (setup-run-cmd)
   forward slm/commands/version with:
     only => (setup-version-cmd)
-

--- a/src/commands/run.stanza
+++ b/src/commands/run.stanza
@@ -1,0 +1,142 @@
+defpackage slm/commands/run:
+  import core
+  import collections
+  import arg-parser
+  import core/parsed-path
+
+  import maybe-utils
+  import semver
+  import term-colors
+  import toml
+
+  import slm/dep-types
+  import slm/dependencies
+  import slm/file-utils
+  import slm/logging
+  import slm/process-utils
+  import slm/flags
+  import slm/toml
+  import slm/utils
+  import slm/stanza-utils
+  import slm/platforms
+
+
+defn get-build-target (cmd-args:CommandArgs) -> Tuple<String> :
+  val arg = args(cmd-args)
+  switch(length(arg)):
+    1:
+      debug("Target: '%_'" % [arg[0]])
+      [arg[0]]
+    0: []
+    else:
+      error("Invalid Number of Targets: %_" % [length(arg)])
+
+public defn run (cmd-args:CommandArgs) -> False:
+  val verbose =  get?(cmd-args, "verbose", false)
+  if verbose:
+    slm/flags/debug? = true
+
+  val force-build = get?(cmd-args, "force", false)
+  val build-args = get?(cmd-args, "-", [])
+  val targ? = get-build-target(cmd-args)
+
+  val cfg = parse-project-toml(SLM_TOML_NAME)
+
+  ; This flag indicates to all dependencies that we are building
+  ;  in static library mode to be able to compile in the build command.
+  set-env("SLM_BUILD_STATIC", "1")
+
+  ; Binary Variable that is used in both build/repl for scripts
+  ;   that want to differentiate that way.
+  ;   This is primarily added for 'conan' because it wants:
+  ;   '--shared=(True|False)'
+  set-env("SLM_BUILD_DYNAMIC_LIB", "False")
+
+  val platform = get-platform()
+  set-env("SLM_PLATFORM", platform)
+
+  debug("calling slm/dependencies/fetch-and-sync")
+  val dependencies = slm/dependencies/fetch-and-sync(cfg, force-build)
+
+  debug("calling get-cwd")
+  val slm-dir = path-join(get-cwd(), SLM_DIR)
+
+  val stanza-exe = get-stanza-exe(compiler?(cfg))
+  debug("with stanza='%_'" % [stanza-exe])
+  debug("with build args '%,'" % [build-args])
+
+  ; In general - we want all of the options for the project to be
+  ;  captured in the `stanza.proj` file - not as options passed to this command.
+  ;  Otherwise, the user will have to remember to pass `-pkg pkgs` on the command
+  ;  line to the `stanza build` if they want to run the compiler directly instead
+  ;  of through `slm`
+  val args = to-tuple $ cat-all([[stanza-exe, "run"], targ?, build-args])
+  val vStr =  version(cfg)
+  debug("Run Version: %_" % [vStr])
+  val env-vars = ["SLM_RUN_VERSION" => vStr]
+  debug("Stanza: %," % [args])
+  ProcessBuilder(args)
+    $> with-env-vars{_, env-vars}
+    $> build
+    $> wait-process-throw-on-nonzero{_, "run failed!"}
+
+  false
+
+val RUN-MSG = \<MSG>
+The 'run' command will manage syncing dependencies and then
+run a file from this project using the 'stanza run' sub-command.
+
+The user can pass arguments to the 'stanza run' process
+by using the '-' flag argument.
+
+Example:
+
+$> slm run -- src/main.stanza -flags TESTING
+
+---------------------------
+Package Version Propagation
+---------------------------
+
+In order for the package's source code to know what its current
+version number is, this tool defines 'SLM_RUN_VERSION' with the
+'version' string value from the 'slm.toml' file. This environment
+variable is defined for the context of the `stanza run` process.
+
+This allows the package's stanza code to use '#env-var(SLM_RUN_VERSION)'
+to access this version string and compile it into the binary or library
+that is being constructed.
+
+The 'slm' binary will also define the 'SLM_PLATFORM' environment
+variable during the dependendency resolution process. This environment
+variable will contain one of the following strings:
+  1.  windows
+  2.  linux
+  3.  os-x
+
+<MSG>
+
+val VERBOSE-FLAG = \<MSG>
+Generate verbose output from build.
+<MSG>
+
+val FORCE-FLAG = \<MSG>
+This flag instructs the build system to ignore any stanza
+version compatibility checks and attempt to build this project
+regardless.
+<MSG>
+
+val RUN-ARGS-FLAG = \<MSG>
+To pass additional run arguments directly to the
+'stanza run' invokation, the user can use the '--'
+sequence. All arguments after the '--' will be
+passed directly to the build.
+<MSG>
+
+public defn setup-run-cmd () -> Command :
+  val runFlags = [
+    Flag("verbose", ZeroFlag, OptionalFlag, VERBOSE-FLAG)
+    Flag("force", ZeroFlag, OptionalFlag, FORCE-FLAG),
+    Flag("-", AllRemainingFlag, OptionalFlag, RUN-ARGS-FLAG)
+
+  ]
+  Command("run", ZeroArg, false, runFlags, RUN-MSG, run)

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -19,6 +19,7 @@ defn setup-opts ():
   add(CMDS, setup-publish-cmd())
   add(CMDS, setup-remove-cmd())
   add(CMDS, setup-repl-cmd())
+  add(CMDS, setup-run-cmd())
   add(CMDS, setup-version-cmd())
 
 val SLM-DESCR = \<MSG>


### PR DESCRIPTION
This pipes the `run` command to the `stanza` process via SLM.

This is a direct copy/pasta from `build` just to get this working. 

We might want to reorganize if we are going to support more stanza commands directly. 