### PR TITLE
Added a better check for the presence of a git repo in `init`

### DIFF
--- a/src/commands/init.stanza
+++ b/src/commands/init.stanza
@@ -130,9 +130,9 @@ public defn init (cmd-args:CommandArgs) -> False:
     val content = MAIN-TEMPLATE % [main-package]
     spit(project-main-path, content)
 
-  ; Initialize Git repo in .git
-  val git-dir = path-join(project-dir, ".git")
-  if has-git?() and not file-exists?(git-dir):
+  ; Initialize Git repo if we aren't already inside
+  ;  a git repo.
+  if has-git?() and not git-status(project-dir):
     git-init(project-dir)
 
   println("slm: init: package `%_` initialized in `%_`"

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -120,19 +120,21 @@ public defn to-version-table (tag-hash:HashTable<String,String>) -> HashTable<Se
       (x:One<SemanticVersion>):
         One(value(x) => hash-str)
 
-public defn run-git-command-in-dir (work-tree?: Maybe<String>, args0: Tuple<String>) -> Int:
+public defn run-git-command-in-dir (args0: Tuple<String> -- work-tree?:Maybe<String> = None(), quiet:True|False = false) -> Int:
   val args = to-tuple $ cat(["git"], args0)
   val work-tree = work-tree? $> value-or{_, get-cwd()}
-  val process = ProcessBuilder(args)
+  var b = ProcessBuilder(args)
     $> in-dir{_, work-tree}
-    $> build
+  if quiet:
+    b = with-output(b) $> with-error-stream{_}
+  val process = build(b)
   wait-process-throw-on-nonzero(process, "'%_' failed!" % [string-join(args, " ")])
 
 public defn run-git-command-in-dir (work-tree: String, args0: Tuple<String>) -> Int:
-  run-git-command-in-dir(One(work-tree), args0)
+  run-git-command-in-dir(args0, work-tree? = One(work-tree))
 
-public defn run-git-command (args0: Tuple<String>) -> Int:
-  run-git-command-in-dir(None(), args0)
+defn run-git-command (args0: Tuple<String>) -> Int:
+  run-git-command-in-dir(args0)
 
 public defn shallow-clone-git-repo (
   url: String,
@@ -145,3 +147,9 @@ public defn git-init (path: String) -> Int:
   run-command-throw-on-error(["git", "init", "--quiet", path],
                              "'git init %_' failed!" % [path])
 
+public defn git-status (work-tree:String = ?) -> True|False :
+  try:
+    run-git-command-in-dir(["status"], work-tree? = work-tree, quiet = true)
+    true
+  catch (e:Exception):
+    false

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -133,7 +133,7 @@ public defn run-git-command-in-dir (args0: Tuple<String> -- work-tree?:Maybe<Str
 public defn run-git-command-in-dir (work-tree: String, args0: Tuple<String>) -> Int:
   run-git-command-in-dir(args0, work-tree? = One(work-tree))
 
-defn run-git-command (args0: Tuple<String>) -> Int:
+public defn run-git-command (args0: Tuple<String>) -> Int:
   run-git-command-in-dir(args0)
 
 public defn shallow-clone-git-repo (

--- a/src/process-utils.stanza
+++ b/src/process-utils.stanza
@@ -14,6 +14,10 @@ public defstruct ProcessBuilder:
     default => false,
     updater => sub-output?
     )
+  error-stream? : True|False with: (
+    default => false,
+    updater => sub-error-stream?
+  )
   env-vars: Tuple<KeyValue<String, String>> with: (
     default => [],
     updater => sub-env-vars
@@ -21,6 +25,9 @@ public defstruct ProcessBuilder:
 
 public defn with-output (builder: ProcessBuilder) -> ProcessBuilder:
   sub-output?(builder, true)
+
+public defn with-error-stream (builder: ProcessBuilder) -> ProcessBuilder :
+  sub-error-stream?(builder, true)
 
 public defn in-dir (builder: ProcessBuilder, dir: String) -> ProcessBuilder:
   sub-working-dir?(builder, One(dir))
@@ -31,12 +38,16 @@ public defn with-env-vars (builder:ProcessBuilder, env-vars:Tuple<KeyValue<Strin
 public defn build (builder: ProcessBuilder) -> Process:
   val args = args(builder)
   val output-stream = if output?(builder): (PROCESS-OUT) else: (STANDARD-OUT)
+  val err-stream = if error-stream?(builder): (PROCESS-OUT) else: (STANDARD-ERR)
   val workdir = value-or(working-dir?(builder), false)
   val env-vars = env-vars(builder)
-  Process(args[0], args, STANDARD-IN, output-stream, STANDARD-ERR, workdir, env-vars)
+  Process(args[0], args, STANDARD-IN, output-stream, err-stream, workdir, env-vars)
 
 public defn get-output (p: Process) -> String:
   slurp-stream(output-stream(p))
+
+public defn get-error-stream (p:Process) -> String:
+  slurp-stream(error-stream(p))
 
 public defn wait-process-throw-on-nonzero (
   process: Process


### PR DESCRIPTION
Bhusan reported that when using `slm init` from with a sub-directory of an existing git repo, that the init command was constructing an unnecessary git repo.

This uses `git status` to check for a git repo as opposed to just checking for the `.git` directory.
