### PR TITLE
Jitx 8574/libgit2 integration

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -10,7 +10,7 @@ lang-utils-static =        { git = "StanzaOrg/slm-lang-utils",        version = 
 maybe-utils =              { git = "StanzaOrg/maybe-utils",           version = "0.1.6" }
 semver      =              { git = "StanzaOrg/semver",                version = "0.1.8" }
 slm-libarchive-static =    { git = "StanzaOrg/slm-libarchive",        version = "0.0.6" }
-slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.1" }
+slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.4" }
 slm-toml    =              { git = "StanzaOrg/slm-toml",              version = "0.4.3" }
 term-colors =              { git = "StanzaOrg/term-colors",           version = "0.1.3" }
 utils-file-system-static = { git = "StanzaOrg/slm-utils-file-system", version = "0.0.14" }

--- a/slm.toml
+++ b/slm.toml
@@ -10,7 +10,7 @@ lang-utils-static =        { git = "StanzaOrg/slm-lang-utils",        version = 
 maybe-utils =              { git = "StanzaOrg/maybe-utils",           version = "0.1.6" }
 semver      =              { git = "StanzaOrg/semver",                version = "0.1.8" }
 slm-libarchive-static =    { git = "StanzaOrg/slm-libarchive",        version = "0.0.6" }
-slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.0.3" }
+slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.0" }
 slm-toml    =              { git = "StanzaOrg/slm-toml",              version = "0.4.3" }
 term-colors =              { git = "StanzaOrg/term-colors",           version = "0.1.3" }
 utils-file-system-static = { git = "StanzaOrg/slm-utils-file-system", version = "0.0.14" }

--- a/slm.toml
+++ b/slm.toml
@@ -10,7 +10,7 @@ lang-utils-static =        { git = "StanzaOrg/slm-lang-utils",        version = 
 maybe-utils =              { git = "StanzaOrg/maybe-utils",           version = "0.1.6" }
 semver      =              { git = "StanzaOrg/semver",                version = "0.1.8" }
 slm-libarchive-static =    { git = "StanzaOrg/slm-libarchive",        version = "0.0.6" }
-slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.0" }
+slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.1" }
 slm-toml    =              { git = "StanzaOrg/slm-toml",              version = "0.4.3" }
 term-colors =              { git = "StanzaOrg/term-colors",           version = "0.1.3" }
 utils-file-system-static = { git = "StanzaOrg/slm-utils-file-system", version = "0.0.14" }

--- a/slm.toml
+++ b/slm.toml
@@ -10,7 +10,7 @@ lang-utils-static =        { git = "StanzaOrg/slm-lang-utils",        version = 
 maybe-utils =              { git = "StanzaOrg/maybe-utils",           version = "0.1.6" }
 semver      =              { git = "StanzaOrg/semver",                version = "0.1.8" }
 slm-libarchive-static =    { git = "StanzaOrg/slm-libarchive",        version = "0.0.6" }
-slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.4" }
+slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.5" }
 slm-toml    =              { git = "StanzaOrg/slm-toml",              version = "0.4.3" }
 term-colors =              { git = "StanzaOrg/term-colors",           version = "0.1.3" }
 utils-file-system-static = { git = "StanzaOrg/slm-utils-file-system", version = "0.0.14" }

--- a/slm.toml
+++ b/slm.toml
@@ -10,7 +10,7 @@ lang-utils-static =        { git = "StanzaOrg/slm-lang-utils",        version = 
 maybe-utils =              { git = "StanzaOrg/maybe-utils",           version = "0.1.6" }
 semver      =              { git = "StanzaOrg/semver",                version = "0.1.8" }
 slm-libarchive-static =    { git = "StanzaOrg/slm-libarchive",        version = "0.0.6" }
-slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.5" }
+slm-libgit2-static =       { git = "StanzaOrg/slm-libgit2",           version = "0.1.6" }
 slm-toml    =              { git = "StanzaOrg/slm-toml",              version = "0.4.3" }
 term-colors =              { git = "StanzaOrg/term-colors",           version = "0.1.3" }
 utils-file-system-static = { git = "StanzaOrg/slm-utils-file-system", version = "0.0.14" }

--- a/src/commands/add.stanza
+++ b/src/commands/add.stanza
@@ -109,15 +109,6 @@ public defn add-git-dependency (
     (_:None):
       ; we need to query the repo for the latest tag
       ;   in the repository.
-      if not has-git?():
-        val PATH = to-maybe $ get-env("PATH")
-        throw $ GitNotFoundError(PATH)
-
-      ; We need at least this version to use `ls-remote`.
-      val exp-git = SemanticVersion(2, 28, 0)
-      if not check-git-version(exp-git) :
-        throw $ GitVersionError(git-version?(), exp-git)
-
       val url = full-url-from-locator(path)
       val tags = git-remote-tag-refs(url)
       debug("Retrieved Tags:")

--- a/src/dependencies.stanza
+++ b/src/dependencies.stanza
@@ -210,7 +210,7 @@ defn resolve-git-dependency? (
       fetch-dependency-at-version(dep)
 
     debug("computing hash for '%_' at '%_'" % [name(dep), path(dep)])
-    val hash = git-rev-parse!(path(dep), "HEAD")
+    val hash = git-or-libgit-rev-parse!(path(dep), "HEAD")
     One(dep $> sub-hash{_, hash})
 
 defn error-incompatible-path-version (dep:PathDependency, obs-version:String):

--- a/src/git-dep.stanza
+++ b/src/git-dep.stanza
@@ -84,16 +84,17 @@ public defn fetch-dependency-at-version (d: GitDependency) -> False:
   val url = full-url-from-locator(locator(d))
   val path = /path(d)
   val tag = to-string("v%~" % [version(d)])
-  val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
 
   ; Use git if available
   if has-git?() :
+    val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
     shallow-clone-git-repo(url, path)
     run-git-command-in-dir(path, ["fetch", "--quiet", "origin", refspec])
     run-git-command-in-dir(path, ["checkout", "--quiet", "--force", tag])
   else :
     ; Fallback to libgit2
-    libgit-clone-tag(url, path, "origin", refspec, tag, true)
+    debug("falling back to libgit for clone")
+    libgit-clone-tag(url, path, "origin", tag, true)
   false
 
 public defn sync-dependency-to-version (dep: GitDependency) -> False:
@@ -119,5 +120,6 @@ public defn sync-dependency-to-version (dep: GitDependency) -> False:
       run-git-command-in-dir(path, ["checkout", "--quiet", "--force", tag])
   else :
     ; Fallback to libgit2
-    libgit-sync-tag(path, "origin", refspec, tag, true, sync-info-msg)
+    debug("falling back to libgit for sync")
+    libgit-sync-tag(path, "origin", tag, true, sync-info-msg)
   false

--- a/src/git-dep.stanza
+++ b/src/git-dep.stanza
@@ -11,6 +11,7 @@ defpackage slm/git-dep:
   import slm/utils
   import slm/logging
   import slm/git-utils
+  import slm/libgit-utils
 
 ; Dependencies specified by Git locator/version (e.g. `foo = "myorg/myuser|1.0.0"`)
 public defstruct GitDependency <: Dependency:
@@ -77,64 +78,46 @@ public defn parse-git-dependency (name:String, locator:String, version?:Maybe<St
   val hash = "" ; This gets resolved during the fetch/sync
   GitDependency(name, locator, version, hash)
 
-public defn fetch-or-sync-at-hash (d: GitDependency) -> False:
-  if not has-git?() :
-    error("No `git` executable found on the path")
-
-  if file-exists?(path(d)):
-    sync-dependency-to-hash(d)
-  else:
-    fetch-dependency-at-hash(d)
-
-
-public defn sync-dependency-to-hash (d: GitDependency) -> False:
-  debug("syncing '%_' at %_" % [name(d), hash(d)])
-
-  if empty?(hash(d)): fatal("internal error")
-
-  if git-rev-parse!(path(d), "HEAD") != hash(d):
-    error("syncing '%_': out of sync with your slm.lock" % [name(d)])
-
-public defn fetch-dependency-at-hash (d: GitDependency) -> False:
-  info("cloning %_ at %_" % [colored-name?(d), hash(d)])
-
-  if empty?(hash(d)): fatal("internal error")
-
-  val url = full-url-from-locator(locator(d))
-  shallow-clone-git-repo(url, path(d))
-
-  run-git-command-in-dir(path(d), ["fetch", "--quiet", "origin", hash(d)])
-  run-git-command-in-dir(path(d), ["checkout", "--quiet", "--force", hash(d)])
-
-  false
-
-
 public defn fetch-dependency-at-version (d: GitDependency) -> False:
   info("cloning %_ at %~" % [colored-name?(d), colored-version?(d)])
 
   val url = full-url-from-locator(locator(d))
-  shallow-clone-git-repo(url, path(d))
-
+  val path = /path(d)
   val tag = to-string("v%~" % [version(d)])
   val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
-  run-git-command-in-dir(path(d), ["fetch", "--quiet", "origin", refspec])
-  run-git-command-in-dir(path(d), ["checkout", "--quiet", "--force", tag])
 
+  ; Use git if available
+  if has-git?() :
+    shallow-clone-git-repo(url, path)
+    run-git-command-in-dir(path, ["fetch", "--quiet", "origin", refspec])
+    run-git-command-in-dir(path, ["checkout", "--quiet", "--force", tag])
+  else :
+    ; Fallback to libgit2
+    libgit-clone-tag(url, path, "origin", refspec, tag, true)
   false
 
 public defn sync-dependency-to-version (dep: GitDependency) -> False:
   debug("checking if we need to sync")
 
-  val head-hash = git-rev-parse!(path(dep), "HEAD")
-  debug("head-hash: %_" % [head-hash])
-
+  val path = /path(dep)
   val tag = to-string("v%~" % [version(dep)])
-  run-git-command-in-dir(path(dep), ["fetch", "--quiet", "origin", tag])
-  val tag-hash = git-rev-parse!(path(dep), tag)
-  debug("tag-hash: %_" % [tag-hash])
+  val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
+  val sync-info-msg = to-string("syncing %_ to %~" % [colored-name?(dep),
+    colored-version?(dep)])
 
-  if tag-hash != head-hash:
-    info("syncing %_ to %~" % [colored-name?(dep), colored-version?(dep)])
-    run-git-command-in-dir(path(dep), ["checkout", "--quiet", "--force", tag])
+  ; Use git if available
+  if has-git?() :
+    val head-hash = git-rev-parse!(path, "HEAD")
+    debug("head-hash: %_" % [head-hash])
 
+    run-git-command-in-dir(path, ["fetch", "--quiet", "origin", refspec])
+    val tag-hash = git-rev-parse!(path, tag)
+    debug("tag-hash: %_" % [tag-hash])
+
+    if tag-hash != head-hash:
+      info(sync-info-msg)
+      run-git-command-in-dir(path, ["checkout", "--quiet", "--force", tag])
+  else :
+    ; Fallback to libgit2
+    libgit-sync-tag(path, "origin", refspec, tag, true, sync-info-msg)
   false

--- a/src/git-dep.stanza
+++ b/src/git-dep.stanza
@@ -78,33 +78,65 @@ public defn parse-git-dependency (name:String, locator:String, version?:Maybe<St
   val hash = "" ; This gets resolved during the fetch/sync
   GitDependency(name, locator, version, hash)
 
-public defn fetch-dependency-at-version (d: GitDependency) -> False:
-  info("cloning %_ at %~" % [colored-name?(d), colored-version?(d)])
+public defn fetch-dependency-at-version (dep:GitDependency) -> False:
+  info("cloning %_ at %~" % [colored-name?(dep), colored-version?(dep)])
   ; Use git if available
   if has-git?() :
-    val url = full-url-from-locator(locator(d))
-    val path = /path(d)
-    val tag = to-string("v%~" % [version(d)])
-    val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
+    ; Clone
+    val url = full-url-from-locator(locator(dep))
+    val path = /path(dep)
     shallow-clone-git-repo(url, path)
+
+    ; Check for "v*.*.*" or "*.*.*" tag
+    val vers = /version(dep)
+    val tag-candidates = [to-string("v%~" % [vers]), to-string(vers)]
+    val tag? = for tag in tag-candidates find :
+      run-git-command-in-dir(path, ["ls-remote", "-q", "-t", "--exit-code",
+        "origin", tag], quiet = true, throw-on-error = false) == 0
+    val tag = match(tag?) :
+      (tag:String) :
+        debug("using tag %_ for dependency %_" % [tag, name(dep)])
+        tag
+      (_) :
+        throw(Exception("Could not checkout version %_ for dependency %_" %
+          [vers, name(dep)]))
+
+    ; Fetch and checkout
+    val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
     run-git-command-in-dir(path, ["fetch", "--quiet", "origin", refspec])
     run-git-command-in-dir(path, ["checkout", "--quiet", "--force", tag])
   else :
     ; Fallback to libgit2
     debug("falling back to libgit for fetch dependency")
-    libgit-fetch-dependency(d)
+    libgit-fetch-dependency(dep)
   false
 
-public defn sync-dependency-to-version (dep: GitDependency) -> False:
+public defn sync-dependency-to-version (dep:GitDependency) -> False:
   debug("checking if we need to sync")
   ; Use git if available
   if has-git?() :
     val path = /path(dep)
-    val tag = to-string("v%~" % [version(dep)])
-    val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
+
+    ; Grab head hash
     val head-hash = git-rev-parse!(path, "HEAD")
     debug("head-hash: %_" % [head-hash])
 
+    ; Check for "v*.*.*" or "*.*.*" tag
+    val vers = /version(dep)
+    val tag-candidates = [to-string("v%~" % [vers]), to-string(vers)]
+    val tag? = for tag in tag-candidates find :
+      run-git-command-in-dir(path, ["ls-remote", "-q", "-t", "--exit-code",
+        "origin", tag], quiet = true, throw-on-error = false) == 0
+    val tag = match(tag?) :
+      (tag:String) :
+        debug("using tag %_ for dependency %_" % [tag, name(dep)])
+        tag
+      (_) :
+        throw(Exception("Could not checkout version %_ for dependency %_" %
+          [vers, name(dep)]))
+
+    ; Fetch and checkout
+    val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
     run-git-command-in-dir(path, ["fetch", "--quiet", "origin", refspec])
     val tag-hash = git-rev-parse!(path, tag)
     debug("tag-hash: %_" % [tag-hash])

--- a/src/git-dep.stanza
+++ b/src/git-dep.stanza
@@ -80,34 +80,28 @@ public defn parse-git-dependency (name:String, locator:String, version?:Maybe<St
 
 public defn fetch-dependency-at-version (d: GitDependency) -> False:
   info("cloning %_ at %~" % [colored-name?(d), colored-version?(d)])
-
-  val url = full-url-from-locator(locator(d))
-  val path = /path(d)
-  val tag = to-string("v%~" % [version(d)])
-
   ; Use git if available
   if has-git?() :
+    val url = full-url-from-locator(locator(d))
+    val path = /path(d)
+    val tag = to-string("v%~" % [version(d)])
     val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
     shallow-clone-git-repo(url, path)
     run-git-command-in-dir(path, ["fetch", "--quiet", "origin", refspec])
     run-git-command-in-dir(path, ["checkout", "--quiet", "--force", tag])
   else :
     ; Fallback to libgit2
-    debug("falling back to libgit for clone")
-    libgit-clone-tag(url, path, "origin", tag, true)
+    debug("falling back to libgit for fetch dependency")
+    libgit-fetch-dependency(d)
   false
 
 public defn sync-dependency-to-version (dep: GitDependency) -> False:
   debug("checking if we need to sync")
-
-  val path = /path(dep)
-  val tag = to-string("v%~" % [version(dep)])
-  val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
-  val sync-info-msg = to-string("syncing %_ to %~" % [colored-name?(dep),
-    colored-version?(dep)])
-
   ; Use git if available
   if has-git?() :
+    val path = /path(dep)
+    val tag = to-string("v%~" % [version(dep)])
+    val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
     val head-hash = git-rev-parse!(path, "HEAD")
     debug("head-hash: %_" % [head-hash])
 
@@ -116,10 +110,10 @@ public defn sync-dependency-to-version (dep: GitDependency) -> False:
     debug("tag-hash: %_" % [tag-hash])
 
     if tag-hash != head-hash:
-      info(sync-info-msg)
+      info("syncing %_ to %~" % [colored-name?(dep), colored-version?(dep)])
       run-git-command-in-dir(path, ["checkout", "--quiet", "--force", tag])
   else :
     ; Fallback to libgit2
     debug("falling back to libgit for sync")
-    libgit-sync-tag(path, "origin", tag, true, sync-info-msg)
+    libgit-sync-dependency(dep)
   false

--- a/src/git-dep.stanza
+++ b/src/git-dep.stanza
@@ -138,7 +138,7 @@ public defn sync-dependency-to-version (dep:GitDependency) -> False:
     ; Fetch and checkout
     val refspec = to-string("+refs/tags/%_:refs/tags/%_" % [tag, tag])
     run-git-command-in-dir(path, ["fetch", "--quiet", "origin", refspec])
-    val tag-hash = git-rev-parse!(path, tag)
+    val tag-hash = git-rev-parse!(path, tag, peel? = true)
     debug("tag-hash: %_" % [tag-hash])
 
     if tag-hash != head-hash:

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -77,21 +77,26 @@ public defn check-git-version (required:SemanticVersion) -> True|False :
     (_:None): false
     (curr:One<SemanticVersion>): value(curr) >= required
 
-public defn git-rev-parse (work-tree: String, rev: String) -> String:
-  command-output-in-dir(work-tree, ["git", "rev-parse", "--verify", "--quiet", rev])
+public defn git-rev-parse (work-tree:String, rev:String --
+                           peel?:True|False = false) -> String :
+  val peeled-rev = append(rev, "^{}") when peel? else rev
+  command-output-in-dir(work-tree, ["git", "rev-parse", "--verify", "--quiet",
+    peeled-rev])
 
-public defn git-rev-parse! (work-tree: String, rev: String) -> String:
-  val ret = git-rev-parse(work-tree, rev)
+public defn git-rev-parse! (work-tree:String, rev:String --
+                            peel?:True|False = false) -> String :
+  val ret = git-rev-parse(work-tree, rev, peel? = peel?)
   if empty?(ret):
     throw(Exception("git rev-parse failed!"))
   ret
 
-public defn git-or-libgit-rev-parse! (work-tree: String, rev: String) -> String :
+public defn git-or-libgit-rev-parse! (work-tree:String, rev:String --
+                                      peel?:True|False = false) -> String :
   if has-git?() :
-    git-rev-parse!(work-tree, rev)
+    git-rev-parse!(work-tree, rev, peel? = peel?)
   else :
     debug("falling back to libgit for rev-parse")
-    libgit-rev-parse(work-tree, rev)
+    libgit-rev-parse(work-tree, rev, peel? = peel?)
 
 public defn git-remote-tag-refs (remote: String) -> HashTable<String, String>:
   val can-use-git? =
@@ -133,28 +138,39 @@ defn remove-prefix? (a:String, prefix:String) -> String :
   val n = length(prefix)
   if (length(a) >= n) and (a[0 to n] == prefix) : a[n to false]
   else : a
-public defn parse-full-git-tag (tag:String) -> Maybe<SemanticVersion> :
-  if is-prefix?(tag, "refs/tags/") :
-    var tag*:String = tag[10 to false]
-    tag* = split-any(tag*, "^~:")[0]
-    tag* = remove-prefix?(tag*, "v")
-    parse-semver(tag*)
-  else :
-    None()
 
 doc: \<DOC>
 Convert the `Tag` => Git Hash table to a SemVer => Hash table.
 
 This takes the output of `git-remote-tag-refs` and converts it into
 a more useable format for querying the versions.
+
+Prefers the peeled commit hash over the tag object hash for annotated tags
 <DOC>
-public defn to-version-table (tag-hash:HashTable<String,String>) -> HashTable<SemanticVersion, String> :
-  to-hashtable<SemanticVersion, String> $ for kvp in tag-hash seq? :
-    val [tag, hash-str] = [key(kvp), value(kvp)]
-    match(parse-full-git-tag(tag)):
-      (x:None): x
-      (x:One<SemanticVersion>):
-        One(value(x) => hash-str)
+public defn to-version-table (tag-hashes:HashTable<String,String>) -> HashTable<SemanticVersion,String> :
+  ; Store preferred hashes (peeled commit hashes) to be applied afterwards
+  val peeled-hashes = Vector<KeyValue<SemanticVersion,String>>()
+  val result = to-hashtable<SemanticVersion,String> $ for kv in tag-hashes seq? :
+    val [tag, hash] = [key(kv), value(kv)]
+    if is-prefix?(tag, "refs/tags/") :
+      var tag*:String = remove-prefix?(tag[10 to false], "v")
+      if contains?(tag*, '^') :
+        val version? = parse-semver(next(split(tag*, "^")))
+        match(version?:One<SemanticVersion>) :
+          add(peeled-hashes, value(version?) => hash)
+        None()
+      else :
+        match(parse-semver(tag*)) :
+          (ver:One<SemanticVersion>) :
+            One(value(ver) => hash)
+          (_:None) : None()
+    else :
+      None()
+  ; Delayed setting of preferred key-value pairs to enforce preference for
+  ; peeled hashes
+  for kv in peeled-hashes do :
+    result[key(kv)] = value(kv)
+  result
 
 public defn run-git-command-in-dir (args0: Tuple<String>
                                     --

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -133,13 +133,15 @@ public defn git-remote-tag-refs (remote: String) -> HashTable<String, String>:
 
 defn is-prefix? (a:String, prefix:String) -> True|False :
   (length(a) >= length(prefix)) and (a[0 to length(prefix)] == prefix)
-
+defn remove-prefix? (a:String, prefix:String) -> String :
+  val n = length(prefix)
+  if (length(a) >= n) and (a[0 to n] == prefix) : a[n to false]
+  else : a
 public defn parse-full-git-tag (tag:String) -> Maybe<SemanticVersion> :
   if is-prefix?(tag, "refs/tags/") :
     var tag*:String = tag[10 to false]
     tag* = split-any(tag*, "^~:")[0]
-    if length(tag) > 0 and tag*[0] == "v" :
-      tag* = tag*[1 to false]
+    tag* = remove-prefix?(tag*, "v")
     parse-semver(tag*)
   else :
     None()

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -35,29 +35,32 @@ defn parse-git-version (msg:String) -> Maybe<SemanticVersion> :
       parse-semver(version-str)
 
 defn run-git-version () -> Maybe<SemanticVersion> :
-  try:
-    val p = ProcessBuilder(["git", "version"])
-      $> with-output
-      $> build
-
-    ; Evidently - you have to call `get-output` before `run` here
-    ;   Otherwise, it will throw an "Bad file descriptor" error.
-    val msg = get-output(p) $> trim
-    val code = run-and-get-exit-code(p)
-    if code == 0:
-      debug("Parsing git version: %_" % [msg])
-      parse-git-version(msg)
-    else if code == 127:
-      ; This indicates that there is no `git` on the path:
-      debug("git version returns code=%_ - Not on Path" % [code])
-      None()
-    else:
-      debug("Error checking 'git version': code = %_ \n %_" % [code, msg])
-      None()
-  catch (e:ProcessLaunchError):
-    ; Launch failure is synonymous with executable not found.
-    debug("Failed to Launch 'git version': %_" % [e])
+  if get-env("SLM_DISABLE_GIT") is-not False :
     None()
+  else :
+    try:
+      val p = ProcessBuilder(["git", "version"])
+        $> with-output
+        $> build
+
+      ; Evidently - you have to call `get-output` before `run` here
+      ;   Otherwise, it will throw an "Bad file descriptor" error.
+      val msg = get-output(p) $> trim
+      val code = run-and-get-exit-code(p)
+      if code == 0:
+        debug("Parsing git version: %_" % [msg])
+        parse-git-version(msg)
+      else if code == 127:
+        ; This indicates that there is no `git` on the path:
+        debug("git version returns code=%_ - Not on Path" % [code])
+        None()
+      else:
+        debug("Error checking 'git version': code = %_ \n %_" % [code, msg])
+        None()
+    catch (e:ProcessLaunchError):
+      ; Launch failure is synonymous with executable not found.
+      debug("Failed to Launch 'git version': %_" % [e])
+      None()
 
 var git-vers:Maybe<SemanticVersion> = run-git-version()
 

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -94,6 +94,7 @@ public defn git-or-libgit-rev-parse! (work-tree: String, rev: String) -> String 
       throw(Exception("git rev-parse failed!"))
     ret
   else :
+    debug("falling back to libgit for rev-parse")
     libgit-rev-parse(work-tree, rev)
 
 public defn git-remote-tag-refs (remote: String) -> HashTable<String, String>:

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -131,6 +131,19 @@ public defn git-remote-tag-refs (remote: String) -> HashTable<String, String>:
   else :
     libgit-lsremote-tags(remote)
 
+defn is-prefix? (a:String, prefix:String) -> True|False :
+  (length(a) >= length(prefix)) and (a[0 to length(prefix)] == prefix)
+
+public defn parse-full-git-tag (tag:String) -> Maybe<SemanticVersion> :
+  if is-prefix?(tag, "refs/tags/") :
+    var tag*:String = tag[10 to false]
+    tag* = split-any(tag*, "^~:")[0]
+    if length(tag) > 0 and tag*[0] == "v" :
+      tag* = tag*[1 to false]
+    parse-semver(tag*)
+  else :
+    None()
+
 doc: \<DOC>
 Convert the `Tag` => Git Hash table to a SemVer => Hash table.
 
@@ -140,18 +153,16 @@ a more useable format for querying the versions.
 public defn to-version-table (tag-hash:HashTable<String,String>) -> HashTable<SemanticVersion, String> :
   to-hashtable<SemanticVersion, String> $ for kvp in tag-hash seq? :
     val [tag, hash-str] = [key(kvp), value(kvp)]
-    val comps = split-any(tag, "^~:")
-    val tagPath = comps[0]
-    val [root, tagName] = split-filepath(tagPath)
-    ; We expect tagName to be in the form `v0.3.2` or something similar.
-    val tagName* = tagName[1 to false]
-    val version? = parse-semver(tagName*)
-    match(version?):
+    match(parse-full-git-tag(tag)):
       (x:None): x
       (x:One<SemanticVersion>):
         One(value(x) => hash-str)
 
-public defn run-git-command-in-dir (args0: Tuple<String> -- work-tree?:Maybe<String> = None(), quiet:True|False = false) -> Int:
+public defn run-git-command-in-dir (args0: Tuple<String>
+                                    --
+                                    work-tree?:Maybe<String> = None(),
+                                    quiet:True|False = false,
+                                    throw-on-error:True|False = true) -> Int:
   val args = to-tuple $ cat(["git"], args0)
   val work-tree = work-tree? $> value-or{_, get-cwd()}
   var b = ProcessBuilder(args)
@@ -159,10 +170,21 @@ public defn run-git-command-in-dir (args0: Tuple<String> -- work-tree?:Maybe<Str
   if quiet:
     b = with-output(b) $> with-error-stream{_}
   val process = build(b)
-  wait-process-throw-on-nonzero(process, "'%_' failed!" % [string-join(args, " ")])
+  val failure-msg = "'%_' failed!" % [string-join(args, " ")]
+  if throw-on-error :
+    wait-process-throw-on-nonzero(process, failure-msg)
+  else :
+    match(wait(process)) :
+      (code:ProcessDone): value(code)
+      (_): throw(Exception(failure-msg))
 
-public defn run-git-command-in-dir (work-tree: String, args0: Tuple<String>) -> Int:
-  run-git-command-in-dir(args0, work-tree? = One(work-tree))
+public defn run-git-command-in-dir (work-tree: String,
+                                    args0: Tuple<String>
+                                    --
+                                    quiet:True|False = false
+                                    throw-on-error:True|False = true) -> Int:
+  run-git-command-in-dir(args0, work-tree? = One(work-tree),
+    quiet = quiet, throw-on-error = throw-on-error)
 
 public defn run-git-command (args0: Tuple<String>) -> Int:
   run-git-command-in-dir(args0)

--- a/src/git-utils.stanza
+++ b/src/git-utils.stanza
@@ -9,6 +9,7 @@ defpackage slm/git-utils:
   import slm/logging
   import slm/file-utils
   import slm/process-utils
+  import slm/libgit-utils
 
 doc: \<DOC>
 Parser the version string returned by git
@@ -82,23 +83,49 @@ public defn git-rev-parse! (work-tree: String, rev: String) -> String:
     throw(Exception("git rev-parse failed!"))
   ret
 
+public defn git-or-libgit-rev-parse! (work-tree: String, rev: String) -> String :
+  if has-git?() :
+    git-rev-parse!(work-tree, rev)
+    val ret = git-rev-parse(work-tree, rev)
+    if empty?(ret):
+      throw(Exception("git rev-parse failed!"))
+    ret
+  else :
+    libgit-rev-parse(work-tree, rev)
+
 public defn git-remote-tag-refs (remote: String) -> HashTable<String, String>:
-  val p = ProcessBuilder(["git", "ls-remote", "-q", "--tags", remote])
-    $> with-output
-    $> build
+  val can-use-git? =
+    if has-git?() :
+      ; We need at least this version to use `ls-remote`.
+      val exp-git = SemanticVersion(2, 28, 0)
+      if check-git-version(exp-git) :
+        true
+      else :
+        debug("falling back to libgit2 for ls-remote")
+        false
+    else :
+      debug("falling back to libgit2 for ls-remote")
+      false
 
-  val output = get-output(p) $> trim
-  val code = run-and-get-exit-code(p)
-  if code != 0:
-    throw $ Exception("Failed to list tags from remote")
+  if can-use-git? :
+    val p = ProcessBuilder(["git", "ls-remote", "-q", "--tags", remote])
+      $> with-output
+      $> build
 
-  val pairs = to-tuple $ split(output, "\n")
-  to-hashtable<String, String> $ seq?{_, pairs} $ fn (line):
-    val elements = to-tuple $ split(line, "\t")
-    if length(elements) == 2:
-      One(elements[1] => elements[0])
-    else:
-      None()
+    val output = get-output(p) $> trim
+    val code = run-and-get-exit-code(p)
+    if code != 0:
+      throw $ Exception("Failed to list tags from remote")
+
+    val pairs = to-tuple $ split(output, "\n")
+    to-hashtable<String, String> $ seq?{_, pairs} $ fn (line):
+      val elements = to-tuple $ split(line, "\t")
+      if length(elements) == 2:
+        One(elements[1] => elements[0])
+      else:
+        None()
+  else :
+    libgit-lsremote-tags(remote)
 
 doc: \<DOC>
 Convert the `Tag` => Git Hash table to a SemVer => Hash table.

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -50,16 +50,19 @@ public defn libgit-rev-parse (path:String, refish:String) -> String :
 
 ; Performs the following steps in order:
 ; 1. Shallow clones the repository at 'url' to path 'path'
-; 2. Fetches objects and references from the remote 'remote-name' (with the
-;    refspec 'refspec' if given)
+; 2. Fetches objects and references from the remote 'remote-name' with a refspec
+;    which limits updates to the specified tag
 ; 3. Checks out the tag 'tag' (forcefully if 'force?' is true)
 ; Throws a LibGitException if unsuccessful
 public defn libgit-clone-tag (url:String,
                               path:String,
                               remote-name:String,
-                              refspec:String|False,
                               tag:String,
                               force?:True|False = false) -> False :
+
+  val full-tag = to-string("refs/tags/%_" % [tag])
+  val refspec = to-string("+%_:%_" % [full-tag, full-tag])
+
   libgit2_init()
 
   ; Clone
@@ -83,7 +86,7 @@ public defn libgit-clone-tag (url:String,
 
   ; Checkout
   val checkout-strat = GIT_CHECKOUT_FORCE when force? else GIT_CHECKOUT_SAFE
-  match(libgit2_checkout(repo, tag, checkout-strat)):
+  match(libgit2_checkout(repo, full-tag, checkout-strat)):
     (e:GIT_OK) :
       false
     (e:git_error_code) :
@@ -100,20 +103,22 @@ public defn libgit-clone-tag (url:String,
 ; Performs the following steps in order:
 ; 1. Opens the repository at path 'path'
 ; 2. Finds the object ID of the repository HEAD
-; 3. Fetches objects and references from the remote 'remote-name' (with the
-;    refspec 'refspec' if given)
+; 3. Fetches references from the remote 'remote-name', but only updates the
+;    local reference 'tag' to match the remote
 ; 4. Finds the object ID of the tag 'tag'
-; 5. If (1) and (3) differ, checks out the tag 'tag' (forcefully if 'force?' is
-;    true)
+; 5. If (1) and (3) differ, checks out the tag 'tag' in detached mode
+;    (forcefully if 'force?' is true)
 ;    If 'sync-info-msg' is supplied, info() will be called with it
 ; Throws a LibGitException if unsuccessful
 public defn libgit-sync-tag (path:String,
                              remote-name:String,
-                             refspec:String|False,
                              tag:String,
                              force?:True|False = false,
                              sync-info-msg:Printable|String|False = false) -> False :
   libgit2_init()
+
+  val full-tag = to-string("refs/tags/%_" % [tag])
+  val refspec = to-string("+%_:%_" % [full-tag, full-tag])
 
   ; Open
   val repo = match(libgit2_repository_open(path)):
@@ -145,7 +150,7 @@ public defn libgit-sync-tag (path:String,
       throw(exc)
 
   ; Rev-parse tag
-  val tag-hash = match(libgit2_revparse(repo, tag)):
+  val tag-hash = match(libgit2_revparse(repo, full-tag)):
     (hash:String) : hash
     (e:git_error_code) :
       val exc = last-libgit-exception(e)
@@ -159,7 +164,7 @@ public defn libgit-sync-tag (path:String,
     match(sync-info-msg:Printable|String) :
       info(sync-info-msg)
     val checkout-strat = GIT_CHECKOUT_FORCE when force? else GIT_CHECKOUT_SAFE
-    match(libgit2_checkout(repo, tag, checkout-strat)):
+    match(libgit2_checkout(repo, full-tag, checkout-strat)):
       (e:GIT_OK) :
         false
       (e:git_error_code) :

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -4,7 +4,10 @@ defpackage slm/libgit-utils:
 
   import libgit2
 
+  import slm/utils
+  import slm/dependency
   import slm/logging
+  import slm/git-dep
 
 ;============================================================
 ;====================== Libgit2 Utils =======================
@@ -15,7 +18,7 @@ public defstruct LibGitException <: Exception :
   msg: ?
 
 public defmethod print (o:OutputStream, e:LibGitException):
-  print(o, "git error: %_" % [msg(e)])
+  print(o, "Libgit error: %_" % [msg(e)])
 
 ; Finds and returns the object ID of the reference 'refish' in the repository at
 ; 'path'
@@ -30,7 +33,7 @@ public defn libgit-rev-parse (path:String, refish:String) -> String :
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to open git repository at %_: %_" % [path, last-err-msg]))
+      throw(LibGitException(e, "Failed to open git repository in %_: %_" % [path, last-err-msg]))
 
   ; Rev-parse
   val result = match(libgit2_revparse(repo, refish)):
@@ -39,7 +42,7 @@ public defn libgit-rev-parse (path:String, refish:String) -> String :
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to parse %_: %_" % [refish, last-err-msg]))
+      throw(LibGitException(e, "Failed to parse reference %_: %_" % [refish, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)
@@ -47,21 +50,19 @@ public defn libgit-rev-parse (path:String, refish:String) -> String :
 
   result
 
-; Performs the following steps in order:
-; 1. Shallow clones the repository at 'url' to path 'path'
-; 2. Fetches objects and references from the remote 'remote-name' with a refspec
-;    which limits updates to the specified tag
-; 3. Checks out the tag 'tag' (forcefully if 'force?' is true)
+; Clones the repository for the Git dependency and performs a forced checkout
+; of the tag of the dependency's version
+; Assumes the remote name is "origin"
 ; Throws an exception if unsuccessful
-public defn libgit-clone-tag (url:String,
-                              path:String,
-                              remote-name:String,
-                              tag:String,
-                              force?:True|False = false) -> False :
-
+public defn libgit-fetch-dependency (dep:GitDependency) -> False :
+  val name = /name(dep)
+  val url = full-url-from-locator(locator(dep))
+  val path = /path(dep)
+  val tag = to-string("v%~" % [version(dep)])
   val full-tag = to-string("refs/tags/%_" % [tag])
   val refspec = to-string("+%_:%_" % [full-tag, full-tag])
 
+  ; Initialize libgit
   libgit2_init()
 
   ; Clone
@@ -71,53 +72,45 @@ public defn libgit-clone-tag (url:String,
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to clone %_: %_" % [url, last-err-msg]))
+      throw(LibGitException(e, "Failed to clone dependency %_ at %_: %_" % [name, url, last-err-msg]))
 
   ; Fetch
-  match(libgit2_fetch(repo, remote-name, refspec, 1)):
+  match(libgit2_fetch(repo, "origin", refspec, 1)):
     (e:GIT_OK) :
       false
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to fetch %_ from %_: %_" % [tag, url, last-err-msg]))
+      throw(LibGitException(e, "Failed to fetch tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
 
   ; Checkout
-  val checkout-strat = GIT_CHECKOUT_FORCE when force? else GIT_CHECKOUT_SAFE
-  match(libgit2_checkout(repo, full-tag, checkout-strat)):
+  match(libgit2_checkout(repo, full-tag, GIT_CHECKOUT_FORCE)):
     (e:GIT_OK) :
       false
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to checkout %_ from %_: %_" % [tag, url, last-err-msg]))
+      throw(LibGitException(e, "Failed to checkout tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)
   libgit2_shutdown()
   false
 
-; Performs the following steps in order:
-; 1. Opens the repository at path 'path'
-; 2. Finds the object ID of the repository HEAD
-; 3. Fetches references from the remote 'remote-name', but only updates the
-;    local reference 'tag' to match the remote
-; 4. Finds the object ID of the tag 'tag'
-; 5. If (1) and (3) differ, checks out the tag 'tag' in detached mode
-;    (forcefully if 'force?' is true)
-;    If 'sync-info-msg' is supplied, info() will be called with it
+; Syncs the repository for the Git dependency to the requested version
+; Assumes the remote name is "origin"
 ; Throws an exception if unsuccessful
-public defn libgit-sync-tag (path:String,
-                             remote-name:String,
-                             tag:String,
-                             force?:True|False = false,
-                             sync-info-msg:Printable|String|False = false) -> False :
-  libgit2_init()
-
+public defn libgit-sync-dependency (dep:GitDependency) -> False :
+  val name = /name(dep)
+  val path = /path(dep)
+  val tag = to-string("v%~" % [version(dep)])
   val full-tag = to-string("refs/tags/%_" % [tag])
   val refspec = to-string("+%_:%_" % [full-tag, full-tag])
+
+  ; Initialize libgit
+  libgit2_init()
 
   ; Open
   val repo = match(libgit2_repository_open(path)):
@@ -126,7 +119,7 @@ public defn libgit-sync-tag (path:String,
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to open git repository at %_: %_" % [path, last-err-msg]))
+      throw(LibGitException(e, "Failed to open git repository for dependency %_ at %_: %_" % [name, path, last-err-msg]))
 
   ; Rev-parse HEAD
   val head-hash = match(libgit2_revparse(repo, "HEAD")):
@@ -135,18 +128,18 @@ public defn libgit-sync-tag (path:String,
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to find hash of HEAD: %_" % [last-err-msg]))
+      throw(LibGitException(e, "Failed to find hash of HEAD for dependency %_ at %_: %_" % [name, path, last-err-msg]))
   debug("head-hash: %_" % [head-hash])
 
   ; Fetch
-  match(libgit2_fetch(repo, remote-name, refspec, 1)):
+  match(libgit2_fetch(repo, "origin", refspec, 1)):
     (e:GIT_OK) :
       false
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to fetch %_: %_" % [tag, last-err-msg]))
+      throw(LibGitException(e, "Failed to fetch tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
 
   ; Rev-parse tag
   val tag-hash = match(libgit2_revparse(repo, full-tag)):
@@ -155,22 +148,20 @@ public defn libgit-sync-tag (path:String,
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "failed to parse %_: %_" % [tag, last-err-msg]))
+      throw(LibGitException(e, "Failed to parse tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
   debug("tag-hash: %_" % [tag-hash])
 
   ; Checkout
   if head-hash != tag-hash :
-    match(sync-info-msg:Printable|String) :
-      info(sync-info-msg)
-    val checkout-strat = GIT_CHECKOUT_FORCE when force? else GIT_CHECKOUT_SAFE
-    match(libgit2_checkout(repo, full-tag, checkout-strat)):
+    info("syncing %_ to %~" % [colored-name?(dep), colored-version?(dep)])
+    match(libgit2_checkout(repo, full-tag, GIT_CHECKOUT_FORCE)):
       (e:GIT_OK) :
         false
       (e:git_error_code) :
         val last-err-msg = message(libgit2_error_last())
         libgit2_repository_free(repo)
         libgit2_shutdown()
-        throw(LibGitException(e, "failed to checkout %_: %_" % [tag, last-err-msg]))
+        throw(LibGitException(e, "Failed to checkout tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)
@@ -189,7 +180,7 @@ public defn libgit-lsremote-tags (remote-url:String) -> HashTable<String,String>
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_shutdown()
-        throw(LibGitException(e, "failed to list remote references of %_: %_" % [remote-url, last-err-msg]))
+        throw(LibGitException(e, "Failed to list remote references of %_: %_" % [remote-url, last-err-msg]))
 
   ; Build table, filter non-tag references
   val result = to-hashtable<String,String> $ for entry in entries filter :

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -76,7 +76,7 @@ public defn libgit-fetch-dependency (dep:GitDependency) -> False :
       throw(LibGitException(e, "Failed to clone dependency %_ at %_: %_" % [name, url, last-err-msg]))
 
   ; Fetch
-  match(libgit2_fetch(repo, "origin", "+refs/tags/*:refs/tags/*", 1)):
+  match(libgit2_fetch(repo, "origin", "+refs/tags/*:refs/tags/*")):
     (e:GIT_OK) :
       false
     (e:git_error_code) :

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -23,7 +23,8 @@ public defmethod print (o:OutputStream, e:LibGitException):
 ; Finds and returns the object ID of the reference 'refish' in the repository at
 ; 'path'
 ; Throws an exception if unsuccessful
-public defn libgit-rev-parse (path:String, refish:String) -> String :
+public defn libgit-rev-parse (path:String, refish:String --
+                              peel?:True|False = false) -> String :
   libgit2_init()
 
   ; Open
@@ -36,13 +37,15 @@ public defn libgit-rev-parse (path:String, refish:String) -> String :
       throw(LibGitException(e, "Failed to open git repository in %_: %_" % [path, last-err-msg]))
 
   ; Rev-parse
-  val result = match(libgit2_revparse(repo, refish)):
+  val peeled-refish = append(refish, "^{}") when peel? else refish
+  val result = match(libgit2_revparse(repo, peeled-refish)):
     (hash:String) : hash
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "Failed to parse reference %_: %_" % [refish, last-err-msg]))
+      throw(LibGitException(e, "Failed to parse reference %_: %_" %
+        [peeled-refish, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)
@@ -124,7 +127,7 @@ public defn libgit-fetch-dependency (dep:GitDependency) -> False :
 public defn libgit-sync-dependency (dep:GitDependency) -> False :
   val name = /name(dep)
   val path = /path(dep)
-  val version = /version(dep)
+  val version-str = to-string(/version(dep))
 
   ; Initialize libgit
   libgit2_init()
@@ -158,14 +161,14 @@ public defn libgit-sync-dependency (dep:GitDependency) -> False :
       libgit2_shutdown()
       throw(LibGitException(e, "Failed to fetch tags for dependency %_: %_" % [name, last-err-msg]))
 
-  ; Find hash of tag for requested version
+  ; Find peeled commit hash of tag for requested version
   ; Try both "v*.*.*" and "*.*.*" styles
-  val non-v-tag = to-string("refs/tags/%_" % [version])
-  val v-tag = to-string("refs/tags/v%_" % [version])
-  val tag+hash? = for tag in [v-tag, non-v-tag] first :
-    match(libgit2_revparse(repo, tag)) :
+  val full-tag+hash? = for tag in [append("v", version-str), version-str] first :
+    val full-tag = to-string("refs/tags/%_" % [tag])
+    val refspec = append(full-tag, "^{}")
+    match(libgit2_revparse(repo, refspec)) :
       (hash:String) :
-        One([tag, hash])
+        One([full-tag, hash])
       (e:GIT_ENOTFOUND) :
         None()
       (e:git_error_code) :
@@ -173,12 +176,12 @@ public defn libgit-sync-dependency (dep:GitDependency) -> False :
         libgit2_repository_free(repo)
         libgit2_shutdown()
         throw(LibGitException(e, "Failed to parse tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
-  val [full-tag, tag-hash] = match(tag+hash?) :
-    (tag+hash:One<[String,String]>) : value(tag+hash)
+  val [full-tag, tag-hash] = match(full-tag+hash?) :
+    (x:One<[String,String]>) : value(x)
     (_:None) :
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(GIT_ENOTFOUND, "No tag found which matches version %_ of %_" % [version, name]))
+      throw(LibGitException(GIT_ENOTFOUND, "No tag found which matches version %_ of %_" % [version-str, name]))
   debug("using tag %_ for dependency %_" % [full-tag, name])
   debug("tag-hash: %_" % [tag-hash])
 

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -18,6 +18,36 @@ public defmethod print (o:OutputStream, e:LibGitException):
   val msg = "libgit2 error: %_" % [msg(e)]
   print(o, msg)
 
+; Finds and returns the object ID of the reference 'refish' in the repository at
+; 'path'
+; Throws a LibGitException if unsuccessful
+public defn libgit-rev-parse (path:String, refish:String) -> String :
+  libgit2_init()
+
+  ; Open
+  val repo = match(libgit2_repository_open(path)):
+    (repo:GIT_REPOSITORY) :
+      repo
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_shutdown()
+      throw(exc)
+
+  ; Rev-parse
+  val result = match(libgit2_revparse(repo, refish)):
+    (hash:String) : hash
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_repository_free(repo)
+      libgit2_shutdown()
+      throw(exc)
+
+  ; Cleanup
+  libgit2_repository_free(repo)
+  libgit2_shutdown()
+
+  result
+
 ; Performs the following steps in order:
 ; 1. Shallow clones the repository at 'url' to path 'path'
 ; 2. Fetches objects and references from the remote 'remote-name' (with the
@@ -142,6 +172,30 @@ public defn libgit-sync-tag (path:String,
   libgit2_repository_free(repo)
   libgit2_shutdown()
   false
+
+; Returns a table of hash => reference name for all tags of the remote at the
+; URL 'remote-url'
+; Throws a LibGitException if unsuccessful
+public defn libgit-lsremote-tags (remote-url:String) -> HashTable<String,String> :
+  libgit2_init()
+
+  ; lsremote
+  val entries = match(libgit2_lsremote_url(remote-url)):
+    (entries:Tuple<KeyValue<String,String>>) : entries
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_shutdown()
+      throw(exc)
+
+  ; Build table, filter non-tag references
+  val result = to-hashtable<String,String> $ for entry in entries filter :
+    val tag = value(entry)
+    (length(tag) > 10) and (tag[0 to 10] == "refs/tags/")
+
+  ; Cleanup
+  libgit2_shutdown()
+
+  result
 
 ;============================================================
 ;========================= Helpers ==========================

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -1,0 +1,152 @@
+defpackage slm/libgit-utils:
+  import core
+  import collections
+
+  import libgit2
+
+  import slm/logging
+
+;============================================================
+;====================== Libgit2 Utils =======================
+;============================================================
+
+public defstruct LibGitException <: Exception :
+  code: git_error_code
+  msg: String
+
+public defmethod print (o:OutputStream, e:LibGitException):
+  val msg = "libgit2 error: %_" % [msg(e)]
+  print(o, msg)
+
+; Performs the following steps in order:
+; 1. Shallow clones the repository at 'url' to path 'path'
+; 2. Fetches objects and references from the remote 'remote-name' (with the
+;    refspec 'refspec' if given)
+; 3. Checks out the tag 'tag' (forcefully if 'force?' is true)
+; Throws a LibGitException if unsuccessful
+public defn libgit-clone-tag (url:String,
+                              path:String,
+                              remote-name:String,
+                              refspec:String|False,
+                              tag:String,
+                              force?:True|False = false) -> False :
+  libgit2_init()
+
+  ; Clone
+  val repo = match(libgit2_clone(url, path, 1)):
+    (repo:GIT_REPOSITORY) :
+      repo
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_shutdown()
+      throw(exc)
+
+  ; Fetch
+  match(libgit2_fetch(repo, remote-name, refspec, 1)):
+    (e:GIT_OK) :
+      false
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_repository_free(repo)
+      libgit2_shutdown()
+      throw(exc)
+
+  ; Checkout
+  val checkout-strat = GIT_CHECKOUT_FORCE when force? else GIT_CHECKOUT_SAFE
+  match(libgit2_checkout(repo, tag, checkout-strat)):
+    (e:GIT_OK) :
+      false
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_repository_free(repo)
+      libgit2_shutdown()
+      throw(exc)
+
+  ; Cleanup
+  libgit2_repository_free(repo)
+  libgit2_shutdown()
+  false
+
+; Performs the following steps in order:
+; 1. Opens the repository at path 'path'
+; 2. Finds the object ID of the repository HEAD
+; 3. Fetches objects and references from the remote 'remote-name' (with the
+;    refspec 'refspec' if given)
+; 4. Finds the object ID of the tag 'tag'
+; 5. If (1) and (3) differ, checks out the tag 'tag' (forcefully if 'force?' is
+;    true)
+;    If 'sync-info-msg' is supplied, info() will be called with it
+; Throws a LibGitException if unsuccessful
+public defn libgit-sync-tag (path:String,
+                             remote-name:String,
+                             refspec:String|False,
+                             tag:String,
+                             force?:True|False = false,
+                             sync-info-msg:String|False = false) -> False :
+  libgit2_init()
+
+  ; Open
+  val repo = match(libgit2_repository_open(path)):
+    (repo:GIT_REPOSITORY) :
+      repo
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_shutdown()
+      throw(exc)
+
+  ; Rev-parse HEAD
+  val head-hash = match(libgit2_revparse(repo, "HEAD")):
+    (hash:String) : hash
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_repository_free(repo)
+      libgit2_shutdown()
+      throw(exc)
+  debug("head-hash: %_" % [head-hash])
+
+  ; Fetch
+  match(libgit2_fetch(repo, remote-name, refspec, 1)):
+    (e:GIT_OK) :
+      false
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_repository_free(repo)
+      libgit2_shutdown()
+      throw(exc)
+
+  ; Rev-parse tag
+  val tag-hash = match(libgit2_revparse(repo, tag)):
+    (hash:String) : hash
+    (e:git_error_code) :
+      val exc = last-libgit-exception(e)
+      libgit2_repository_free(repo)
+      libgit2_shutdown()
+      throw(exc)
+  debug("tag-hash: %_" % [tag-hash])
+
+  ; Checkout
+  if head-hash != tag-hash :
+    match(sync-info-msg:String) :
+      info(sync-info-msg)
+    val checkout-strat = GIT_CHECKOUT_FORCE when force? else GIT_CHECKOUT_SAFE
+    match(libgit2_checkout(repo, tag, checkout-strat)):
+      (e:GIT_OK) :
+        false
+      (e:git_error_code) :
+        val exc = last-libgit-exception(e)
+        libgit2_repository_free(repo)
+        libgit2_shutdown()
+        throw(exc)
+
+  ; Cleanup
+  libgit2_repository_free(repo)
+  libgit2_shutdown()
+  false
+
+;============================================================
+;========================= Helpers ==========================
+;============================================================
+
+; Grab the most recent libgit error message
+defn last-libgit-exception (e:git_error_code) :
+  LibGitException(e, message(libgit2_error_last()))

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -82,7 +82,7 @@ public defn libgit-sync-tag (path:String,
                              refspec:String|False,
                              tag:String,
                              force?:True|False = false,
-                             sync-info-msg:String|False = false) -> False :
+                             sync-info-msg:Printable|String|False = false) -> False :
   libgit2_init()
 
   ; Open
@@ -126,7 +126,7 @@ public defn libgit-sync-tag (path:String,
 
   ; Checkout
   if head-hash != tag-hash :
-    match(sync-info-msg:String) :
+    match(sync-info-msg:Printable|String) :
       info(sync-info-msg)
     val checkout-strat = GIT_CHECKOUT_FORCE when force? else GIT_CHECKOUT_SAFE
     match(libgit2_checkout(repo, tag, checkout-strat)):

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -12,15 +12,14 @@ defpackage slm/libgit-utils:
 
 public defstruct LibGitException <: Exception :
   code: git_error_code
-  msg: String
+  msg: ?
 
 public defmethod print (o:OutputStream, e:LibGitException):
-  val msg = "libgit2 error: %_" % [msg(e)]
-  print(o, msg)
+  print(o, "git error: %_" % [msg(e)])
 
 ; Finds and returns the object ID of the reference 'refish' in the repository at
 ; 'path'
-; Throws a LibGitException if unsuccessful
+; Throws an exception if unsuccessful
 public defn libgit-rev-parse (path:String, refish:String) -> String :
   libgit2_init()
 
@@ -29,18 +28,18 @@ public defn libgit-rev-parse (path:String, refish:String) -> String :
     (repo:GIT_REPOSITORY) :
       repo
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to open git repository at %_: %_" % [path, last-err-msg]))
 
   ; Rev-parse
   val result = match(libgit2_revparse(repo, refish)):
     (hash:String) : hash
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to parse %_: %_" % [refish, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)
@@ -53,7 +52,7 @@ public defn libgit-rev-parse (path:String, refish:String) -> String :
 ; 2. Fetches objects and references from the remote 'remote-name' with a refspec
 ;    which limits updates to the specified tag
 ; 3. Checks out the tag 'tag' (forcefully if 'force?' is true)
-; Throws a LibGitException if unsuccessful
+; Throws an exception if unsuccessful
 public defn libgit-clone-tag (url:String,
                               path:String,
                               remote-name:String,
@@ -70,19 +69,19 @@ public defn libgit-clone-tag (url:String,
     (repo:GIT_REPOSITORY) :
       repo
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to clone %_: %_" % [url, last-err-msg]))
 
   ; Fetch
   match(libgit2_fetch(repo, remote-name, refspec, 1)):
     (e:GIT_OK) :
       false
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to fetch %_ from %_: %_" % [tag, url, last-err-msg]))
 
   ; Checkout
   val checkout-strat = GIT_CHECKOUT_FORCE when force? else GIT_CHECKOUT_SAFE
@@ -90,10 +89,10 @@ public defn libgit-clone-tag (url:String,
     (e:GIT_OK) :
       false
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to checkout %_ from %_: %_" % [tag, url, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)
@@ -109,7 +108,7 @@ public defn libgit-clone-tag (url:String,
 ; 5. If (1) and (3) differ, checks out the tag 'tag' in detached mode
 ;    (forcefully if 'force?' is true)
 ;    If 'sync-info-msg' is supplied, info() will be called with it
-; Throws a LibGitException if unsuccessful
+; Throws an exception if unsuccessful
 public defn libgit-sync-tag (path:String,
                              remote-name:String,
                              tag:String,
@@ -125,18 +124,18 @@ public defn libgit-sync-tag (path:String,
     (repo:GIT_REPOSITORY) :
       repo
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to open git repository at %_: %_" % [path, last-err-msg]))
 
   ; Rev-parse HEAD
   val head-hash = match(libgit2_revparse(repo, "HEAD")):
     (hash:String) : hash
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to find hash of HEAD: %_" % [last-err-msg]))
   debug("head-hash: %_" % [head-hash])
 
   ; Fetch
@@ -144,19 +143,19 @@ public defn libgit-sync-tag (path:String,
     (e:GIT_OK) :
       false
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to fetch %_: %_" % [tag, last-err-msg]))
 
   ; Rev-parse tag
   val tag-hash = match(libgit2_revparse(repo, full-tag)):
     (hash:String) : hash
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(exc)
+      throw(LibGitException(e, "failed to parse %_: %_" % [tag, last-err-msg]))
   debug("tag-hash: %_" % [tag-hash])
 
   ; Checkout
@@ -168,10 +167,10 @@ public defn libgit-sync-tag (path:String,
       (e:GIT_OK) :
         false
       (e:git_error_code) :
-        val exc = last-libgit-exception(e)
+        val last-err-msg = message(libgit2_error_last())
         libgit2_repository_free(repo)
         libgit2_shutdown()
-        throw(exc)
+        throw(LibGitException(e, "failed to checkout %_: %_" % [tag, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)
@@ -180,7 +179,7 @@ public defn libgit-sync-tag (path:String,
 
 ; Returns a table of hash => reference name for all tags of the remote at the
 ; URL 'remote-url'
-; Throws a LibGitException if unsuccessful
+; Throws an exception if unsuccessful
 public defn libgit-lsremote-tags (remote-url:String) -> HashTable<String,String> :
   libgit2_init()
 
@@ -188,9 +187,9 @@ public defn libgit-lsremote-tags (remote-url:String) -> HashTable<String,String>
   val entries = match(libgit2_lsremote_url(remote-url)):
     (entries:Tuple<KeyValue<String,String>>) : entries
     (e:git_error_code) :
-      val exc = last-libgit-exception(e)
+      val last-err-msg = message(libgit2_error_last())
       libgit2_shutdown()
-      throw(exc)
+        throw(LibGitException(e, "failed to list remote references of %_: %_" % [remote-url, last-err-msg]))
 
   ; Build table, filter non-tag references
   val result = to-hashtable<String,String> $ for entry in entries filter :
@@ -201,11 +200,3 @@ public defn libgit-lsremote-tags (remote-url:String) -> HashTable<String,String>
   libgit2_shutdown()
 
   result
-
-;============================================================
-;========================= Helpers ==========================
-;============================================================
-
-; Grab the most recent libgit error message
-defn last-libgit-exception (e:git_error_code) :
-  LibGitException(e, message(libgit2_error_last()))

--- a/src/libgit-utils.stanza
+++ b/src/libgit-utils.stanza
@@ -58,9 +58,7 @@ public defn libgit-fetch-dependency (dep:GitDependency) -> False :
   val name = /name(dep)
   val url = full-url-from-locator(locator(dep))
   val path = /path(dep)
-  val tag = to-string("v%~" % [version(dep)])
-  val full-tag = to-string("refs/tags/%_" % [tag])
-  val refspec = to-string("+%_:%_" % [full-tag, full-tag])
+  val version = /version(dep)
 
   ; Initialize libgit
   libgit2_init()
@@ -75,14 +73,35 @@ public defn libgit-fetch-dependency (dep:GitDependency) -> False :
       throw(LibGitException(e, "Failed to clone dependency %_ at %_: %_" % [name, url, last-err-msg]))
 
   ; Fetch
-  match(libgit2_fetch(repo, "origin", refspec, 1)):
+  match(libgit2_fetch(repo, "origin", "+refs/tags/*:refs/tags/*", 1)):
     (e:GIT_OK) :
       false
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "Failed to fetch tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
+      throw(LibGitException(e, "Failed to fetch tags for dependency %_: %_" % [name, last-err-msg]))
+
+  ; Determine which style of tag exits for requested version
+  ; Try both "v*.*.*" and "*.*.*" styles
+  val non-v-tag = to-string("refs/tags/%_" % [version])
+  val v-tag = to-string("refs/tags/v%_" % [version])
+  val full-tag? = for tag in [v-tag, non-v-tag] find :
+    match(libgit2_revparse(repo, tag)) :
+      (hash:String) : true
+      (e:GIT_ENOTFOUND) : false
+      (e:git_error_code) :
+        val last-err-msg = message(libgit2_error_last())
+        libgit2_repository_free(repo)
+        libgit2_shutdown()
+        throw(LibGitException(e, "Failed to parse tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
+  val full-tag = match(full-tag?) :
+    (tag:String) : tag
+    (_) :
+      libgit2_repository_free(repo)
+      libgit2_shutdown()
+      throw(LibGitException(GIT_ENOTFOUND, "No tag found which matches version %_ of %_" % [version, name]))
+  debug("using tag %_ for dependency %_" % [full-tag, name])
 
   ; Checkout
   match(libgit2_checkout(repo, full-tag, GIT_CHECKOUT_FORCE)):
@@ -92,7 +111,7 @@ public defn libgit-fetch-dependency (dep:GitDependency) -> False :
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "Failed to checkout tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
+      throw(LibGitException(e, "Failed to checkout tag %_ for dependency %_: %_" % [full-tag, name, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)
@@ -105,9 +124,7 @@ public defn libgit-fetch-dependency (dep:GitDependency) -> False :
 public defn libgit-sync-dependency (dep:GitDependency) -> False :
   val name = /name(dep)
   val path = /path(dep)
-  val tag = to-string("v%~" % [version(dep)])
-  val full-tag = to-string("refs/tags/%_" % [tag])
-  val refspec = to-string("+%_:%_" % [full-tag, full-tag])
+  val version = /version(dep)
 
   ; Initialize libgit
   libgit2_init()
@@ -132,23 +149,37 @@ public defn libgit-sync-dependency (dep:GitDependency) -> False :
   debug("head-hash: %_" % [head-hash])
 
   ; Fetch
-  match(libgit2_fetch(repo, "origin", refspec, 1)):
+  match(libgit2_fetch(repo, "origin", "+refs/tags/*:refs/tags/*", 1)):
     (e:GIT_OK) :
       false
     (e:git_error_code) :
       val last-err-msg = message(libgit2_error_last())
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "Failed to fetch tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
+      throw(LibGitException(e, "Failed to fetch tags for dependency %_: %_" % [name, last-err-msg]))
 
-  ; Rev-parse tag
-  val tag-hash = match(libgit2_revparse(repo, full-tag)):
-    (hash:String) : hash
-    (e:git_error_code) :
-      val last-err-msg = message(libgit2_error_last())
+  ; Find hash of tag for requested version
+  ; Try both "v*.*.*" and "*.*.*" styles
+  val non-v-tag = to-string("refs/tags/%_" % [version])
+  val v-tag = to-string("refs/tags/v%_" % [version])
+  val tag+hash? = for tag in [v-tag, non-v-tag] first :
+    match(libgit2_revparse(repo, tag)) :
+      (hash:String) :
+        One([tag, hash])
+      (e:GIT_ENOTFOUND) :
+        None()
+      (e:git_error_code) :
+        val last-err-msg = message(libgit2_error_last())
+        libgit2_repository_free(repo)
+        libgit2_shutdown()
+        throw(LibGitException(e, "Failed to parse tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
+  val [full-tag, tag-hash] = match(tag+hash?) :
+    (tag+hash:One<[String,String]>) : value(tag+hash)
+    (_:None) :
       libgit2_repository_free(repo)
       libgit2_shutdown()
-      throw(LibGitException(e, "Failed to parse tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
+      throw(LibGitException(GIT_ENOTFOUND, "No tag found which matches version %_ of %_" % [version, name]))
+  debug("using tag %_ for dependency %_" % [full-tag, name])
   debug("tag-hash: %_" % [tag-hash])
 
   ; Checkout
@@ -161,7 +192,7 @@ public defn libgit-sync-dependency (dep:GitDependency) -> False :
         val last-err-msg = message(libgit2_error_last())
         libgit2_repository_free(repo)
         libgit2_shutdown()
-        throw(LibGitException(e, "Failed to checkout tag %_ for dependency %_: %_" % [tag, name, last-err-msg]))
+        throw(LibGitException(e, "Failed to checkout tag %_ for dependency %_: %_" % [full-tag, name, last-err-msg]))
 
   ; Cleanup
   libgit2_repository_free(repo)

--- a/src/main.stanza
+++ b/src/main.stanza
@@ -42,8 +42,8 @@ Environment Variables:
 - 'SLM_PROTOCOL' - This variable can select the transport protocol
     used to download dependencies from Github.
     'https' -> HTTPS Protocol
-    'git' -> Git Protocol
-    The default is 'git'.
+    'ssh' -> SSH Protocol
+    The default is 'https'.
 - 'SLM_STANZA' = This variable can select the name and/or path to
     the stanza executable. This allows for usage with macro extended
     compilers. If set, this value will override the 'compiler'

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -8,6 +8,7 @@ defpackage slm/utils:
 
   import slm/errors
   import slm/file-utils
+  import slm/git-utils
 
 
 public defn clear-color? (c: ColoredString) -> ColoredString:
@@ -43,14 +44,19 @@ public defn last?<?T> (c: Seqable<?T>) -> Maybe<T>:
 public defn first<?T> (t: Tuple<?T>) -> T:
   t[1]
 
+defn ssh-locator (locator: String) -> String :
+  to-string("git@github.com:%_" % [locator])
+defn https-locator (locator: String) -> String :
+  to-string("https://github.com/%_" % [locator])
 public defn full-url-from-locator (locator: String) -> String:
-  defn git-locator (locator: String): (to-string("git@github.com:%_" % [locator]))
-  defn https-locator (locator: String): (to-string("https://github.com/%_" % [locator]))
-
   switch(get-env("SLM_PROTOCOL")):
-    "git": git-locator(locator)
+    "ssh":
+      if has-git?() :
+        ssh-locator(locator)
+      else :
+        throw(Exception("Error: SLM_PROTOCOL is set to SSH but Git was not found"))
     "https": https-locator(locator)
-    else: git-locator(locator)
+    else: https-locator(locator)
 
 doc: \<DOC>
 Join Strings to form a file system path.

--- a/tests/git-utils.stanza
+++ b/tests/git-utils.stanza
@@ -12,6 +12,7 @@ deftest(git-utils) test-to-version-table:
   val inputvec = to-hashtable<String, String>([
     "refs/tags/v0.1.0" => "0001",
     "refs/tags/v0.2.0" => "0002",
+    "refs/tags/v0.2.1" => "0006", ; This should be ignored in favor of the peeled hash
     "refs/tags/v0.2.1^{}" => "0003",
     "refs/tags/v0.2.2^{}" => "0004",
     "refs/tags/cja_test" => "0005",   ; This should get filtered out.
@@ -29,4 +30,3 @@ deftest(git-utils) test-to-version-table:
   #EXPECT(length(obs) == length(exp))
   for k in keys(exp) do:
     #EXPECT(obs[k] == exp[k])
-


### PR DESCRIPTION
Adds libgit fallbacks for clone, fetch, checkout, lsremote, and rev-parse. Also changes the default SLM_PROTOCOL to HTTPS and adds an error if SSH is requested without Git installed. Does not add fallbacks for git push (for slm publish) and git init (for slm init) yet.