### PR TITLE
Added the `SLM_DIR` environment variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ build:
 	${CONAN} config install conan-config
 	 #${CONAN} remote enable conancenter
 	[ ! -e ".conan2/profiles/default" ] && ${CONAN} profile detect
-	(cd conan_lbstanza_generator && ${CONAN} create .)
 
 	 # get the current project name from the slm.toml file
 	SLMPROJNAME=$$(${SED} -n -e '/^ *name *= *"*\([^"]*\).*/{s//\1/;p;q}' slm.toml)

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,14 @@ upload:
 	echo -e "\n*** Makefile: upload: uploading \"$${SLMPROJNAME}/$${SLMPROJVER}\" ***"
 	${CONAN} upload -r artifactory $${SLMPROJNAME}/$${SLMPROJVER}
 
+	cd slm_builder/conan_lbstanza_generator
+	${CONAN} create .
+	 # get the generator name and version from the conanfile.py file
+	PYSLMPROJNAME=$$(${SED} -n -e '/^ *name *= *"*\([^"]*\).*/{s//\1/;p;q}' conanfile.py)
+	PYSLMPROJVER=$$(${SED} -n -e '/^ *version *= *"*\([^"]*\).*/{s//\1/;p;q}' conanfile.py)
+	-e "\n*** Makefile: upload: uploading \"$${PYSLMPROJNAME}/$${PYSLMPROJVER}\" ***"
+	${CONAN} upload -r artifactory $${PYSLMPROJNAME}/$${PYSLMPROJVER}
+
 .PHONY: clean
 clean:
 	@CLEANCMD="rm -rf .conan2 .slm build venv"

--- a/conan_lbstanza_generator/conanfile.py
+++ b/conan_lbstanza_generator/conanfile.py
@@ -79,11 +79,11 @@ class LBStanzaGenerator:
             if is_shared_lib:
                 outf.write(f'  dynamic-libraries:\n')
                 outf.write(f'    on-platform:\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["linux"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["linux"]])
                 outf.write(f'      linux: ( {s} )\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["macos"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["macos"]])
                 outf.write(f'      os-x: ( {s} )\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["windows"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["windows"]])
                 outf.write(f'      windows: ( {s} )\n')
             else:  # static
                 pass
@@ -91,12 +91,12 @@ class LBStanzaGenerator:
             outf.write(f'    on-platform:\n')
             incdirall = ""
             for incdir in include_dirs:
-                incdirall += f" \"-I{incdir}\" "
-            s = " ".join([f'"{str(p)}"' for p in libs["linux"]])
+                incdirall += f" \"-I{incdir.replace('\\', '/')}\" "
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["linux"]])
             outf.write(f'      linux: ( {incdirall} {startgrp} {s} {extralibslnx} {endgrp} )\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["macos"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["macos"]])
             outf.write(f'      os-x: ( {incdirall} {s} {extralibsmac} )\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["windows"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["windows"]])
             outf.write(f'      windows: ( {incdirall} {startgrp} {s} {extralibswin} {endgrp} )\n')
 
             outf.write(f'\n')
@@ -106,31 +106,25 @@ class LBStanzaGenerator:
             if is_shared_lib:
                 outf.write(f'  dynamic-libraries:\n')
                 outf.write(f'    on-platform:\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["linux"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["linux"]])
                 outf.write(f'      linux: ( {s} )\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["macos"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["macos"]])
                 outf.write(f'      os-x: ( {s} )\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["windows"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["windows"]])
                 outf.write(f'      windows: ( {s} )\n')
             else:  # static
                 pass
             outf.write(f'  ccflags:\n')
             outf.write(f'    on-platform:\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["linux"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["linux"]])
             outf.write(f'      linux: ( {incdirall} {startgrp} {s} {extralibslnx} {endgrp} )\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["macos"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["macos"]])
             outf.write(f'      os-x: ( {incdirall} {s} {extralibsmac} )\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["windows"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["windows"]])
             outf.write(f'      windows: ( {incdirall} {startgrp} {s} {extralibswin} {endgrp} )\n')
 
 
     def get_component_libs_from_dependency(self, depname: str, depinst: ConanFileInterface) -> list:
-        # remove any "lib" prefix from depname
-        depname = depname.partition('/')[0].removeprefix("lib")
-        # make sure we can use this name as an identifier
-        if not depname.isalnum():
-            self._conanfile.output.error(f"Unepxected non-alphanumeric dependency name: \"{depname}\"")
-
         #self._conanfile.output.trace(f"    - depinst.cppinfo: \"{depinst.cpp_info.serialize()}\"")
         #self._conanfile.output.trace(f"    - depinst.cppinfo:")
         #self._conanfile.output.trace(jsons.dumps(depinst.cpp_info.serialize(), jdkwargs={"indent": 2}))
@@ -144,8 +138,8 @@ class LBStanzaGenerator:
         self._conanfile.output.trace(f"    - get_component_libs_from_dependency(\"{depname}\", inst) -> \"{complist}\"")
         return complist
 
-    def write_cpp_info_to_fragment(self, is_shared_lib: bool, include_dirs: list[str], libs: dict[str, Path]):
-        self._conanfile.output.trace(f"  > write_component_libs_to_fragment({is_shared_lib}, \"{libs}\"")
+    def write_cpp_info_to_fragment(self, is_shared_lib: bool, include_dirs: list[str], libs: dict[str, dict[str, Path]]):
+        self._conanfile.output.trace(f"  > write_cpp_info_to_fragment({is_shared_lib}, \"{libs}\"")
         outerlibname = self._conanfile.name.removeprefix("slm-")
         relative_path = Path(f"{{.}}/../{outerlibname}/lib")
 
@@ -156,28 +150,33 @@ class LBStanzaGenerator:
             for os in ["linux", "macos", "windows"]:
                 libfilenames[tp][os] = []
 
-        for l, p in libs.items():
-            # calculate filenames
-            if is_shared_lib:
-                flnx = f"lib{l}.so"
-                fmac = f"lib{l}.dylib"
-                fwin = f"lib{l}.so"
-            else:
-                flnx = f"lib{l}.a"
-                fmac = f"lib{l}.a"
-                fwin = f"lib{l}.a"
-            libfilenames["full"]["linux"].append(Path(p) / flnx)
-            libfilenames["full"]["macos"].append(Path(p) / fmac)
-            libfilenames["full"]["windows"].append(Path(p) / fwin)
-            libfilenames["relative"]["linux"].append(relative_path / flnx)
-            libfilenames["relative"]["macos"].append(relative_path / fmac)
-            libfilenames["relative"]["windows"].append(relative_path / fwin)
+        for pkgname, d in libs.items():
+            for l, p in d.items():
+                # calculate filenames
+                if is_shared_lib:
+                    flnx = f"lib{l}.so"
+                    fmac = f"lib{l}.dylib"
+                    fwin = f"lib{l}.dll"
+                else:
+                    flnx = f"lib{l}.a"
+                    fmac = f"lib{l}.a"
+                    fwin = f"lib{l}.a"
+                libfilenames["full"]["linux"].append(Path(p) / flnx)
+                libfilenames["full"]["macos"].append(Path(p) / fmac)
+                libfilenames["full"]["windows"].append(Path(p) / fwin)
+                
+                relative_path = Path(f"{{.}}/../{pkgname}/lib")
+                libfilenames["relative"]["linux"].append(relative_path / flnx)
+                libfilenames["relative"]["macos"].append(relative_path / fmac)
+                libfilenames["relative"]["windows"].append(relative_path / fwin)
 
         # debug output filenames
         for os, td in libfilenames.items():
             for tp, a in td.items():
                 self._conanfile.output.trace(f"  {tp}-{os}: {', '.join([str(p) for p in a])}")
 
+        #breakpoint()
+        
         # Write stanza.proj fragment with full library paths for dependencies in conan cache
         outfilename = f"stanza-{outerlibname}.proj"
         self._conanfile.output.trace(f"Generating {outfilename} for {outerlibname}")
@@ -195,6 +194,7 @@ class LBStanzaGenerator:
         for dep in self._conanfile.dependencies.items():
             dreq = dep[0]
             dinst = dep[1]
+            depname = str(dreq.ref).partition('/')[0]
             self._conanfile.output.trace(f"")
             #self._conanfile.output.trace(f"  checking dep \"{dreq.serialize()}\"")
             self._conanfile.output.trace(f"  - dependency: {dreq.ref}")
@@ -203,7 +203,7 @@ class LBStanzaGenerator:
             self._conanfile.output.trace(f"    - package_path: {dinst.package_path if dinst.package_folder else 'None'}")
 
             if not dreq.libs:
-                self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" is not a lib, skipping")
+                self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" has no libs, skipping")
                 continue
             if len(dinst.cpp_info.components) > 0:
                 self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" components:")
@@ -213,7 +213,10 @@ class LBStanzaGenerator:
                 for cl in self.get_component_libs_from_dependency(str(dreq.ref), dinst):
                     self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" component \"{cl}\"")
                     # cl is a dictionary {name: path}
-                    libs.update(cl)
+                    if depname in libs:
+                        libs[depname].update(cl)
+                    else:
+                        libs[depname] = cl
             else:
                 self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" include dirs: {dinst.cpp_info.includedirs}")
                 self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" lib dirs: {dinst.cpp_info.libdirs}")
@@ -228,10 +231,14 @@ class LBStanzaGenerator:
                     for l in dinst.cpp_info.libs:
                         d[l] = libdir
                     # d is a dictionary {name: path}
-                    libs.update(d)
+                    if depname in libs:
+                        libs[depname].update(d)
+                    else:
+                        libs[depname] = d
                 else:
                     self._conanfile.output.error(f"Dependency \"{dreq.ref}\" defined libs with no libdirs")
 
+            #breakpoint()
 
         self.write_cpp_info_to_fragment(is_shared_lib, incdirs, libs)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -22,7 +22,8 @@ class ConanSlmPackage(ConanFile):
   package_id_non_embed_mode = "unrelated_mode"
   package_id_python_mode = "unrelated_mode"
   package_type = "application"
-  python_requires = "lbstanzagenerator_pyreq/[>=0.1]"
+  python_requires = "lbstanzagenerator_pyreq/0.1"
+  #python_requires = "lbstanzagenerator_pyreq/[>=0.6 <1.0]"
 
   # Binary configuration
   #settings = "os", "arch", "compiler", "build_type"
@@ -126,13 +127,13 @@ class ConanSlmPackage(ConanFile):
     self.output.info("conanfile.py: build_requirements()")
   
     # use stanza provided by conan
-    self.tool_requires("lbstanza/[>=0.18.78]")
+    self.tool_requires("lbstanza/[>=0.18.78 <1.0]")
     self.tool_requires("slm/0.6.9")
 
     # use cmake and ninja provided by conan
     # necessary if compiling non-stanza dependencies
-    self.tool_requires("cmake/[>3.20]")
-    self.tool_requires("ninja/[>1.11]")
+    self.tool_requires("cmake/[>=3.20 <4.0]")
+    self.tool_requires("ninja/[>=1.11 <2.0]")
   
     # use mingw-builds compiler provided by conan on windows
     if self.settings.os == "Windows":

--- a/slm_builder/conan_lbstanza_generator/conanfile.py
+++ b/slm_builder/conan_lbstanza_generator/conanfile.py
@@ -11,6 +11,11 @@ from io import TextIOWrapper
 from pathlib import Path
 import jsons
 
+class LBStanzaGeneratorPyReq(ConanFile):
+    name = "lbstanzagenerator_pyreq"
+    version = "0.6.10"
+    package_type = "python-require"
+
 # LBStanza Generator class
 class LBStanzaGenerator:
 
@@ -79,11 +84,11 @@ class LBStanzaGenerator:
             if is_shared_lib:
                 outf.write(f'  dynamic-libraries:\n')
                 outf.write(f'    on-platform:\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["linux"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["linux"]])
                 outf.write(f'      linux: ( {s} )\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["macos"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["macos"]])
                 outf.write(f'      os-x: ( {s} )\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["windows"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["windows"]])
                 outf.write(f'      windows: ( {s} )\n')
             else:  # static
                 pass
@@ -91,12 +96,12 @@ class LBStanzaGenerator:
             outf.write(f'    on-platform:\n')
             incdirall = ""
             for incdir in include_dirs:
-                incdirall += f" \"-I{incdir}\" "
-            s = " ".join([f'"{str(p)}"' for p in libs["linux"]])
+                incdirall += f" \"-I{incdir.replace('\\', '/')}\" "
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["linux"]])
             outf.write(f'      linux: ( {incdirall} {startgrp} {s} {extralibslnx} {endgrp} )\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["macos"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["macos"]])
             outf.write(f'      os-x: ( {incdirall} {s} {extralibsmac} )\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["windows"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["windows"]])
             outf.write(f'      windows: ( {incdirall} {startgrp} {s} {extralibswin} {endgrp} )\n')
 
             outf.write(f'\n')
@@ -106,31 +111,25 @@ class LBStanzaGenerator:
             if is_shared_lib:
                 outf.write(f'  dynamic-libraries:\n')
                 outf.write(f'    on-platform:\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["linux"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["linux"]])
                 outf.write(f'      linux: ( {s} )\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["macos"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["macos"]])
                 outf.write(f'      os-x: ( {s} )\n')
-                s = " ".join([f'"{str(p)}"' for p in libs["windows"]])
+                s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["windows"]])
                 outf.write(f'      windows: ( {s} )\n')
             else:  # static
                 pass
             outf.write(f'  ccflags:\n')
             outf.write(f'    on-platform:\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["linux"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["linux"]])
             outf.write(f'      linux: ( {incdirall} {startgrp} {s} {extralibslnx} {endgrp} )\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["macos"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["macos"]])
             outf.write(f'      os-x: ( {incdirall} {s} {extralibsmac} )\n')
-            s = " ".join([f'"{str(p)}"' for p in libs["windows"]])
+            s = " ".join([f'"{str(p).replace('\\', '/')}"' for p in libs["windows"]])
             outf.write(f'      windows: ( {incdirall} {startgrp} {s} {extralibswin} {endgrp} )\n')
 
 
     def get_component_libs_from_dependency(self, depname: str, depinst: ConanFileInterface) -> list:
-        # remove any "lib" prefix from depname
-        depname = depname.partition('/')[0].removeprefix("lib")
-        # make sure we can use this name as an identifier
-        if not depname.isalnum():
-            self._conanfile.output.error(f"Unepxected non-alphanumeric dependency name: \"{depname}\"")
-
         #self._conanfile.output.trace(f"    - depinst.cppinfo: \"{depinst.cpp_info.serialize()}\"")
         #self._conanfile.output.trace(f"    - depinst.cppinfo:")
         #self._conanfile.output.trace(jsons.dumps(depinst.cpp_info.serialize(), jdkwargs={"indent": 2}))
@@ -144,7 +143,7 @@ class LBStanzaGenerator:
         self._conanfile.output.trace(f"    - get_component_libs_from_dependency(\"{depname}\", inst) -> \"{complist}\"")
         return complist
 
-    def write_cpp_info_to_fragment(self, is_shared_lib: bool, include_dirs: list[str], libs: dict[str, Path]):
+    def write_cpp_info_to_fragment(self, is_shared_lib: bool, include_dirs: list[str], libs: dict[str, dict[str, Path]]):
         self._conanfile.output.trace(f"  > write_cpp_info_to_fragment({is_shared_lib}, \"{libs}\"")
         outerlibname = self._conanfile.name.removeprefix("slm-")
         relative_path = Path(f"{{.}}/../{outerlibname}/lib")
@@ -156,28 +155,33 @@ class LBStanzaGenerator:
             for os in ["linux", "macos", "windows"]:
                 libfilenames[tp][os] = []
 
-        for l, p in libs.items():
-            # calculate filenames
-            if is_shared_lib:
-                flnx = f"lib{l}.so"
-                fmac = f"lib{l}.dylib"
-                fwin = f"lib{l}.dll"
-            else:
-                flnx = f"lib{l}.a"
-                fmac = f"lib{l}.a"
-                fwin = f"lib{l}.a"
-            libfilenames["full"]["linux"].append(Path(p) / flnx)
-            libfilenames["full"]["macos"].append(Path(p) / fmac)
-            libfilenames["full"]["windows"].append(Path(p) / fwin)
-            libfilenames["relative"]["linux"].append(relative_path / flnx)
-            libfilenames["relative"]["macos"].append(relative_path / fmac)
-            libfilenames["relative"]["windows"].append(relative_path / fwin)
+        for pkgname, d in libs.items():
+            for l, p in d.items():
+                # calculate filenames
+                if is_shared_lib:
+                    flnx = f"lib{l}.so"
+                    fmac = f"lib{l}.dylib"
+                    fwin = f"lib{l}.dll"
+                else:
+                    flnx = f"lib{l}.a"
+                    fmac = f"lib{l}.a"
+                    fwin = f"lib{l}.a"
+                libfilenames["full"]["linux"].append(Path(p) / flnx)
+                libfilenames["full"]["macos"].append(Path(p) / fmac)
+                libfilenames["full"]["windows"].append(Path(p) / fwin)
+                
+                relative_path = Path(f"{{.}}/../{pkgname}/lib")
+                libfilenames["relative"]["linux"].append(relative_path / flnx)
+                libfilenames["relative"]["macos"].append(relative_path / fmac)
+                libfilenames["relative"]["windows"].append(relative_path / fwin)
 
         # debug output filenames
         for os, td in libfilenames.items():
             for tp, a in td.items():
                 self._conanfile.output.trace(f"  {tp}-{os}: {', '.join([str(p) for p in a])}")
 
+        #breakpoint()
+        
         # Write stanza.proj fragment with full library paths for dependencies in conan cache
         outfilename = f"stanza-{outerlibname}.proj"
         self._conanfile.output.trace(f"Generating {outfilename} for {outerlibname}")
@@ -195,6 +199,7 @@ class LBStanzaGenerator:
         for dep in self._conanfile.dependencies.items():
             dreq = dep[0]
             dinst = dep[1]
+            depname = str(dreq.ref).partition('/')[0]
             self._conanfile.output.trace(f"")
             #self._conanfile.output.trace(f"  checking dep \"{dreq.serialize()}\"")
             self._conanfile.output.trace(f"  - dependency: {dreq.ref}")
@@ -203,7 +208,7 @@ class LBStanzaGenerator:
             self._conanfile.output.trace(f"    - package_path: {dinst.package_path if dinst.package_folder else 'None'}")
 
             if not dreq.libs:
-                self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" is not a lib, skipping")
+                self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" has no libs, skipping")
                 continue
             if len(dinst.cpp_info.components) > 0:
                 self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" components:")
@@ -213,7 +218,10 @@ class LBStanzaGenerator:
                 for cl in self.get_component_libs_from_dependency(str(dreq.ref), dinst):
                     self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" component \"{cl}\"")
                     # cl is a dictionary {name: path}
-                    libs.update(cl)
+                    if depname in libs:
+                        libs[depname].update(cl)
+                    else:
+                        libs[depname] = cl
             else:
                 self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" include dirs: {dinst.cpp_info.includedirs}")
                 self._conanfile.output.trace(f"    - dep \"{dreq.ref}\" lib dirs: {dinst.cpp_info.libdirs}")
@@ -228,10 +236,14 @@ class LBStanzaGenerator:
                     for l in dinst.cpp_info.libs:
                         d[l] = libdir
                     # d is a dictionary {name: path}
-                    libs.update(d)
+                    if depname in libs:
+                        libs[depname].update(d)
+                    else:
+                        libs[depname] = d
                 else:
                     self._conanfile.output.error(f"Dependency \"{dreq.ref}\" defined libs with no libdirs")
 
+            #breakpoint()
 
         self.write_cpp_info_to_fragment(is_shared_lib, incdirs, libs)
 
@@ -242,7 +254,3 @@ class LBStanzaGenerator:
 
         self._conanfile.output.trace("----")
 
-class LBStanzaGeneratorPyReq(ConanFile):
-    name = "lbstanzagenerator_pyreq"
-    version = "0.1"
-    package_type = "python-require"

--- a/slm_builder/conanfile.py
+++ b/slm_builder/conanfile.py
@@ -27,7 +27,7 @@ class ConanSlmPackage(ConanFile):
   settings = "os", "arch"
 
   options = {"shared": [True, False], "fPIC": [True, False]}
-  default_options = {"shared": True, "fPIC": True}
+  default_options = {"shared": True, "fPIC": True, "*/*:shared": True}
   implements = ["auto_shared_fpic"]
 
 

--- a/src/commands/build.stanza
+++ b/src/commands/build.stanza
@@ -60,6 +60,7 @@ public defn build (cmd-args:CommandArgs) -> False:
 
   debug("calling get-cwd")
   val slm-dir = path-join(get-cwd(), SLM_DIR)
+  set-env("SLM_DIR", slm-dir)
 
   val stanza-exe = get-stanza-exe(compiler?(cfg))
   debug("with stanza='%_'" % [stanza-exe])
@@ -127,6 +128,15 @@ variable will contain one of the following strings:
   1.  windows
   2.  linux
   3.  os-x
+
+----------------------------
+SLM_DIR
+----------------------------
+
+This command will define the `SLM_DIR` environment variable and
+it will point at the `.slm` directory for the top-level project
+being built. This will give subsequent child builds access to
+a known directory from which to find other dependencies.
 
 <MSG>
 

--- a/src/commands/repl.stanza
+++ b/src/commands/repl.stanza
@@ -35,6 +35,7 @@ public defn repl (cmd-args:CommandArgs) -> False:
 
   val args = to-tuple $ cat-all([[stanza-exe, "repl"], repl-args])
   val slm-dir = path-join(get-cwd(), SLM_DIR)
+  set-env("SLM_DIR", slm-dir)
 
   val vStr =  version(cfg)
   debug("Build Version: %_" % [vStr])
@@ -93,6 +94,15 @@ variable will contain one of the following strings:
   1.  windows
   2.  linux
   3.  os-x
+
+----------------------------
+SLM_DIR
+----------------------------
+
+This command will define the `SLM_DIR` environment variable and
+it will point at the `.slm` directory for the top-level project
+being built. This will give subsequent child builds access to
+a known directory from which to find other dependencies.
 
 <MSG>
 

--- a/src/commands/run.stanza
+++ b/src/commands/run.stanza
@@ -60,6 +60,7 @@ public defn run (cmd-args:CommandArgs) -> False:
 
   debug("calling get-cwd")
   val slm-dir = path-join(get-cwd(), SLM_DIR)
+  set-env("SLM_DIR", slm-dir)
 
   val stanza-exe = get-stanza-exe(compiler?(cfg))
   debug("with stanza='%_'" % [stanza-exe])
@@ -112,6 +113,15 @@ variable will contain one of the following strings:
   1.  windows
   2.  linux
   3.  os-x
+
+----------------------------
+SLM_DIR
+----------------------------
+
+This command will define the `SLM_DIR` environment variable and
+it will point at the `.slm` directory for the top-level project
+being built. This will give subsequent child builds access to
+a known directory from which to find other dependencies.
 
 <MSG>
 


### PR DESCRIPTION
In various `stanza.proj` files, I often encounter a pattern where I want to reference the top level `.slm` directory of a project. This ends up being a relative path reference with a `..` in it.

This poses a problem if you want to run the project locally to build, for example, the unit tests for a project.

This env-var makes it so the stanza.proj files don't have to use the relative path and can instead reference a direct location with `{SLM_DIR/deps/some-lib/...`

This is particularly present in [StanzaOrg/slm-z3](https://github.com/StanzaOrg/slm-z3). 

@jwatson0  - thoughts ? 