### PR TITLE
Fix `package` path logic in generated `stanza.proj`

### DIFF
--- a/src/commands/init.stanza
+++ b/src/commands/init.stanza
@@ -64,7 +64,7 @@ public defn init (cmd-args:CommandArgs) -> False:
   val minimal? = flag?(cmd-args, "minimal")
   val project-dir = get-proj-dir(cmd-args)
 
-  val project-name = dir-name?(project-dir)
+  val project-name = base-name?(project-dir)
     $> value-or{_, project-dir}
 
   val slm-toml-path = path-join(project-dir, SLM_TOML_NAME)

--- a/src/file-utils.stanza
+++ b/src/file-utils.stanza
@@ -45,9 +45,6 @@ lostanza defn int-get-cwd () -> ref<String>:
 public defn get-cwd () -> String :
   un-norm-path $ int-get-cwd()
 
-public defn dir-name? (path: String) -> Maybe<String>:
-  split-last(path, '/') $> map{_, first}
-
 public defn base-name? (path: String) -> Maybe<String>:
   path
     $> entries{parse-path(_)}

--- a/src/utils.stanza
+++ b/src/utils.stanza
@@ -29,7 +29,7 @@ public defn pairs<?K, ?V> (s: Seqable<KeyValue<?K, ?V>>) -> Seq<[K, V]>:
   s $> to-seq $> seq{fn (kv): [key(kv), value(kv)], _}
 
 public defn nth?<?T> (c: IndexedCollection<?T>, n: Int) -> Maybe<T>:
-  if n < length(c):
+  if n < length(c) and n >= 0:
     One(get(c, n))
   else:
     None()
@@ -40,9 +40,6 @@ public defn last?<?T> (c: Seqable<?T>) -> Maybe<T>:
       last
     else:
       loop(s, One(next(s)))
-
-public defn first<?T> (t: Tuple<?T>) -> T:
-  t[1]
 
 defn ssh-locator (locator: String) -> String :
   to-string("git@github.com:%_" % [locator])

--- a/stanza.proj
+++ b/stanza.proj
@@ -27,6 +27,7 @@ build-test tests:
     slm/tests/commands/remove
     slm/tests/conan-utils
     slm/tests/process-utils
+    slm/tests/file-utils
   pkg: "test-pkgs"
   o: "slm-tests"
 

--- a/tests/file-utils.stanza
+++ b/tests/file-utils.stanza
@@ -1,0 +1,16 @@
+#use-added-syntax(tests)
+defpackage slm/tests/file-utils:
+  import core
+  import slm/file-utils
+
+deftest(file-utils) test-basename:
+
+  val test-cases = [
+    "C:\\Users\\Bad Name with spaces/my_dir"
+    "C:\\Users\\Bad Name with spaces\\my_dir"
+    "C:\\Users\\Bad Name with spaces/my_dir/"
+    "C:\\Users\\Bad Name with spaces/my_dir\\"
+  ]
+
+  for tc in test-cases do :
+    #EXPECT(base-name?(tc) == One("my_dir"))

--- a/tests/libgit2.stanza
+++ b/tests/libgit2.stanza
@@ -24,7 +24,8 @@ deftest(libgit2) test-error-last :
 
 deftest(libgit2 online) test-clone :
   libgit2_init()
-  val r:git_error_code|GIT_REPOSITORY = libgit2_clone("https://github.com/StanzaOrg/stanza-toml.git", "./foo")
+  val foo-folder = to-string("./foo-%_" % [current-time-ms()])
+  val r:git_error_code|GIT_REPOSITORY = libgit2_clone("https://github.com/StanzaOrg/stanza-toml.git", foo-folder)
   match(r):
     (e:git_error_code) :
       println("libgit2_clone returned error: %_" % [e])
@@ -34,3 +35,4 @@ deftest(libgit2 online) test-clone :
       libgit2_repository_free(gr)
       #EXPECT(true)
   libgit2_shutdown()
+  delete-recursive(foo-folder)

--- a/tests/toml.stanza
+++ b/tests/toml.stanza
@@ -57,7 +57,7 @@ deftest(toml) test-find-dependency:
 
 deftest(toml) test-parse-slm-toml:
   set-env("TEST_VAR", "/home/charles")
-  val uut = parse-slm-toml("./tests/data/test.toml")
+  val uut = parse-slm-toml-file("./tests/data/test.toml")
   unset-env("TEST_VAR")
 
   #EXPECT(name(uut) == "test-slm")
@@ -118,7 +118,7 @@ deftest(toml) test-parse-mutex-error:
   set-env("TEST_VAR", "/home/charles")
 
   defn fail-on-mutex-git-path () :
-    parse-slm-toml("./tests/data/error_git_path_mutex.toml")
+    parse-slm-toml-file("./tests/data/error_git_path_mutex.toml")
 
   val msg = expect-throw(fail-on-mutex-git-path)
 
@@ -132,7 +132,7 @@ deftest(toml) test-parse-malformed-error:
   set-env("TEST_VAR", "/home/charles")
 
   defn fail-on-no-git-path () :
-    parse-slm-toml("./tests/data/error_no_git_or_path.toml")
+    parse-slm-toml-file("./tests/data/error_no_git_or_path.toml")
 
   val msg = expect-throw(fail-on-no-git-path)
 


### PR DESCRIPTION
- remove buggy and confusing `first` function
- remove buggy `dir-name?` function
- use `base-name?` for package directory detection
- add test cases for `base-name?` function
- fix stale broken tests using `parse-slm-toml-file`
- fix cleanup in libgit test
- fix bug in `nth?`