### PR TITLE
Change conan to Vendor mode to adapt to conan 2.8.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -18,15 +18,16 @@ from shutil import copy2, copytree
 required_conan_version = ">=2.0"
 
 class ConanSlmPackage(ConanFile):
-  package_id_embed_mode = "unrelated_mode"
-  package_id_non_embed_mode = "unrelated_mode"
-  package_id_python_mode = "unrelated_mode"
   package_type = "application"
   python_requires = "lbstanzagenerator_pyreq/[>=0.6.17 <0.7.0]"
 
   # Binary configuration
   #settings = "os", "arch", "compiler", "build_type"
   settings = "os", "arch"
+
+  # hide all dependencies from consumers
+  # https://blog.conan.io/2024/07/09/Introducing-vendoring-packages.html
+  vendor = True
 
 
   # set_name(): Dynamically define the name of a package

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-conan~=2.0
+conan~=2.7.1
 jsons~=1.6.3
 requests>=2.31.0

--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "slm"
-version = "0.6.17"
+version = "0.6.18"
 
 # note that the slm bootstrap.py script doesn't recursively resolve dependencies
 # so define a flat list of all required dependencies here


### PR DESCRIPTION
- **requirements.txt: pin to conan 2.7.1 temporarily**
- **conanfile.py: use vendor mode instead of unrelated_mode**
- **Release 0.6.18**
