### PR TITLE
Update conan_lbstanza_generator to avoid conan private datastructures for conan 2.12.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -20,7 +20,7 @@ required_conan_version = ">=2.0"
 
 class ConanSlmPackage(ConanFile):
   package_type = "application"
-  python_requires = "lbstanzagenerator_pyreq/[>=0.6.18 <0.7.0]"
+  python_requires = "lbstanzagenerator_pyreq/[>=0.6.20 <0.7.0]"
 
   # Binary configuration
   #settings = "os", "arch", "compiler", "build_type"


### PR DESCRIPTION
- **slm_builder/conan_lbstanza_generator: 0.6.20 - avoid conan private datastructures for conan 2.12.0**
- **conanfile.py: use lbstanzagenerator_pyreq 0.6.20 for conan 2.12.0**
